### PR TITLE
Include shared entry file in tests for real coverage

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -53,7 +53,7 @@ function getConfig({target, env, dir, watch, cover}) {
   if (env !== 'production' && env !== 'development' && env !== 'test') {
     throw new Error('Invalid name: must be `production`, `dev`, or `test`');
   }
-  if (!fs.existsSync(path.resolve(dir))) {
+  if (!fs.existsSync(path.resolve(dir, main))) {
     throw new Error(`Project directory must contain a ${main} file`);
   }
   if (

--- a/build/compiler.js
+++ b/build/compiler.js
@@ -118,7 +118,7 @@ function getConfig({target, env, dir, watch, cover}) {
           watch &&
           target !== 'node' &&
           `${require.resolve('webpack-hot-middleware/client')}?name=${name}`,
-        // TODO: use 'webpack/hot/signal' instead
+        // TODO(#46): use 'webpack/hot/signal' instead
         env === 'development' &&
           watch &&
           target === 'node' &&
@@ -126,7 +126,7 @@ function getConfig({target, env, dir, watch, cover}) {
         entry,
       ].filter(Boolean),
     },
-    // TODO: Do we need to do something different here for production?
+    // TODO(#47): Do we need to do something different here for production?
     stats: 'minimal',
     /**
      * `cheap-module-source-map` is best supported by Chrome DevTools

--- a/build/compiler.js
+++ b/build/compiler.js
@@ -40,13 +40,6 @@ const rimraf = require('rimraf');
 function getConfig({target, env, dir, watch, cover}) {
   const main = 'src/main.js';
 
-  const serverOnlyTestGlob = `${dir}/src/**/__tests__/*.node.js`;
-  const browserOnlyTestGlob = `${dir}/src/**/__tests__/*.browser.js`;
-  const universalTestGlob = `${dir}/src/**/__tests__/*.js`;
-
-  const serverTestEntry = `__SECRET_MULTI_ENTRY_LOADER__?include[]=${universalTestGlob},exclude[]=${browserOnlyTestGlob}!`;
-  const browserTestEntry = `__SECRET_MULTI_ENTRY_LOADER__?include[]=${universalTestGlob},exclude[]=${serverOnlyTestGlob}!`;
-
   if (target !== 'node' && target !== 'web' && target !== 'webworker') {
     throw new Error('Invalid target: must be `node`, `web`, or `webworker`');
   }
@@ -56,6 +49,14 @@ function getConfig({target, env, dir, watch, cover}) {
   if (!fs.existsSync(path.resolve(dir, main))) {
     throw new Error(`Project directory must contain a ${main} file`);
   }
+
+  const serverOnlyTestGlob = `${dir}/src/**/__tests__/*.node.js`;
+  const browserOnlyTestGlob = `${dir}/src/**/__tests__/*.browser.js`;
+  const universalTestGlob = `${dir}/src/**/__tests__/*.js`;
+
+  const serverTestEntry = `__SECRET_MULTI_ENTRY_LOADER__?include[]=${universalTestGlob},include[]=${dir}/${main},exclude[]=${browserOnlyTestGlob}!`;
+  const browserTestEntry = `__SECRET_MULTI_ENTRY_LOADER__?include[]=${universalTestGlob},include[]=${dir}/${main},exclude[]=${serverOnlyTestGlob}!`;
+
   if (
     env === 'test' &&
     !globby.sync([universalTestGlob, `!${browserOnlyTestGlob}`]).length


### PR DESCRIPTION
A common issue with [nyc/istanbul](https://github.com/istanbuljs/nyc) is the coverage only covers as far as the test entry points reach but not the whole bundle, giving a false sense of high coverage. Here's a similar issue describing the problem: gotwarlost/istanbul#112

`--include-all-sources` in `Istanbul v1`, now `--all` in `Istanbul v2/nyc` extends the coverage area to the whole bundle. However, our bundles including test bundles are tree-shaked, therefore the option won't save the situation.

The changes here include shared entry point(currently `src/main.js` to test entry points passing to [multi-entry-loader](https://www.npmjs.com/package/multi-entry-loader)

Open for comments, given this basically eliminates tree-shaking for test bundles.