### PR TITLE
Use shared babel-preset file for transform

### DIFF
--- a/build/babel-preset.js
+++ b/build/babel-preset.js
@@ -13,13 +13,14 @@ module.exports = function buildPreset(
   opts /*: PresetOpts */
 ) {
   const target = opts.targets.hasOwnProperty('node') ? 'node' : 'browser';
+  const modules = opts.modules === undefined ? false : opts.modules;
   return {
     presets: [
       [
         require('babel-preset-env'),
         {
           targets: opts.targets,
-          modules: false,
+          modules: modules,
           exclude: ['transform-regenerator', 'transform-async-to-generator'],
         },
       ],

--- a/build/jest-transformer.js
+++ b/build/jest-transformer.js
@@ -1,8 +1,13 @@
 /* eslint-env node */
 
-const transformer = require('babel-jest').createTransformer({
-  presets: ['babel-preset-flow', 'babel-preset-react'].map(require.resolve),
+const babelConfig = require('./babel-preset.js')(null, {
+  targets: {
+    node: 'current',
+  },
+  modules: 'commonjs',
 });
+
+const transformer = require('babel-jest').createTransformer(babelConfig);
 
 const originalProcessFn = transformer.process;
 


### PR DESCRIPTION
This uses our shared babel preset for tests so we don't need to duplicate a list of presets.

Fixes #68 
