### PR TITLE
Support running test-app against both node and browser targets

### DIFF
--- a/build/babel-preset.js
+++ b/build/babel-preset.js
@@ -35,7 +35,12 @@ module.exports = function buildPreset(
           useBuiltIns: true,
         },
       ],
-      [require.resolve('babel-plugin-transform-cup-globals'), {target: target}],
+      ...(opts.transformGlobals
+        ? [
+            require.resolve('babel-plugin-transform-cup-globals'),
+            {target: target},
+          ]
+        : []),
       ...(target === 'browser'
         ? [
             [

--- a/build/jest-config.js
+++ b/build/jest-config.js
@@ -3,9 +3,16 @@
 module.exports = {
   cache: true,
   rootDir: process.cwd(),
+  globals: {
+    __NODE__: process.env.JEST_ENV === 'node',
+    __BROWSER__: process.env.JEST_ENV === 'jsdom',
+  },
   setupFiles: [
     require.resolve('./jest-framework-shims.js'),
     require.resolve('./jest-framework-setup.js'),
+  ],
+  testPathIgnorePatterns: [
+    process.env.JEST_ENV === 'node' ? '.*\\.browser\\.js' : '.*\\.node\\.js',
   ],
   transform: {
     '^.+\\.js$': require.resolve('./jest-transformer.js'),

--- a/build/jest-framework-setup.js
+++ b/build/jest-framework-setup.js
@@ -4,7 +4,3 @@ import Adapter from 'enzyme-adapter-react-16';
 
 // Setup Enzyme for all Jest tests
 configure({adapter: new Adapter()});
-
-const testEnv = process.env.ENV || 'browser';
-global.__NODE__ = testEnv === 'node';
-global.__BROWSER__ = testEnv === 'browser';

--- a/build/jest-transformer.js
+++ b/build/jest-transformer.js
@@ -5,6 +5,7 @@ const babelConfig = require('./babel-preset.js')(null, {
     node: 'current',
   },
   modules: 'commonjs',
+  transformGlobals: false,
 });
 
 const transformer = require('babel-jest').createTransformer(babelConfig);

--- a/build/test-app-runtime.js
+++ b/build/test-app-runtime.js
@@ -6,49 +6,75 @@ module.exports.TestAppRuntime = function({
   dir = '.',
   watch = false,
   match,
+  env,
   configPath,
 }) {
-  const state = {proc: null};
+  const state = {procs: []};
 
   this.run = () => {
     this.stop();
+    const allTestEnvs = env.split(',');
     let command = require.resolve('jest-cli/bin/jest.js');
-    let args = ['--config', configPath];
 
-    if (watch) {
-      args.push('--watch');
-    }
+    const getArgs = () => {
+      let args = ['--config', configPath];
 
-    if (match && match.length > 0) {
-      args.push(match);
-    }
+      if (watch) {
+        args.push('--watch');
+      }
 
-    return new Promise((resolve, reject) => {
-      state.proc = spawn(command, args, {
-        cwd: path.resolve(process.cwd(), dir),
-        stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
-        env: Object.assign({}, process.env),
-      });
+      if (match && match.length > 0) {
+        args.push(match);
+      }
 
-      state.proc.on('error', reject);
-      state.proc.on('exit', (code, signal) => {
-        if (code) {
-          return reject(new Error(`Test exited with code ${code}`));
+      return args;
+    };
+
+    const spawnProc = testEnv => {
+      return new Promise((resolve, reject) => {
+        const args = getArgs();
+        args.push('--env');
+        args.push(testEnv);
+
+        const procEnv = {
+          JEST_ENV: testEnv,
+        };
+
+        // Pass in the CI flag to prevent console clearing when watching on more than one suite
+        if (allTestEnvs.length > 1 && watch) {
+          procEnv.CI = 'true';
         }
 
-        if (signal) {
-          return reject(new Error(`Test process exited with signal ${signal}`));
-        }
+        const proc = spawn(command, args, {
+          cwd: path.resolve(process.cwd(), dir),
+          stdio: 'inherit',
+          env: Object.assign(procEnv, process.env),
+        });
+        proc.on('error', reject);
+        proc.on('exit', (code, signal) => {
+          if (code) {
+            return reject(new Error(`Test exited with code ${code}`));
+          }
 
-        return resolve();
+          if (signal) {
+            return reject(
+              new Error(`Test process exited with signal ${signal}`)
+            );
+          }
+
+          return resolve();
+        });
+        state.procs.push(proc);
       });
-    });
+    };
+
+    return Promise.all(allTestEnvs.map(spawnProc));
   };
 
   this.stop = () => {
-    if (state.proc) {
-      state.proc.kill();
-      state.proc = null;
+    if (state.procs.length) {
+      state.procs.forEach(proc => proc.kill());
+      state.procs = [];
     }
   };
 };

--- a/commands/test-app.js
+++ b/commands/test-app.js
@@ -18,6 +18,12 @@ exports.builder = {
     default: null,
     describe: 'Runs test files that match a given string',
   },
+  env: {
+    type: 'string',
+    default: 'jsdom,node',
+    describe:
+      'Comma-separated list of environments to run tests in. Defaults to running both node and browser tests.',
+  },
   configPath: {
     type: 'string',
     default: './node_modules/fusion-cli/build/jest-config.js',
@@ -25,8 +31,8 @@ exports.builder = {
   },
 };
 
-exports.run = async function({dir = '.', watch, match, configPath}) {
-  const testRuntime = new TestAppRuntime({dir, watch, match, configPath});
+exports.run = async function({dir = '.', watch, match, env, configPath}) {
+  const testRuntime = new TestAppRuntime({dir, watch, match, env, configPath});
 
   await testRuntime.run();
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "eslint-plugin-react": "^7.1.0",
     "flow-bin": "^0.59.0",
     "fusion-core": "^0.1.8",
-    "fusion-test-utils": "^0.2.3",
+    "fusion-test-utils": "0.2.4",
     "globby": "^6.1.0",
     "prettier": "1.4.2",
     "react": "^16.2.0",

--- a/test/cli/test-app.js
+++ b/test/cli/test-app.js
@@ -6,6 +6,7 @@ const test = require('tape');
 const {promisify} = require('util');
 const exec = promisify(require('child_process').exec);
 
+const countTests = require('../fixtures/test-jest-app/count-tests');
 const runnerPath = require.resolve('../../bin/cli-runner');
 
 test('`fusion test-app` passes', async t => {
@@ -13,8 +14,8 @@ test('`fusion test-app` passes', async t => {
   const args = `test-app --dir=${dir} --configPath=../../../build/jest-config.js --match=passes`;
 
   const cmd = `require('${runnerPath}').run('${args}')`;
-  await exec(`node -e "${cmd}"`);
-
+  const response = await exec(`node -e "${cmd}"`);
+  t.equal(countTests(response.stderr), 2, 'ran 2 tests');
   t.end();
 });
 
@@ -25,8 +26,46 @@ test('`fusion test-app` failure', async t => {
   const cmd = `require('${runnerPath}').run('${args}')`;
   try {
     await exec(`node -e "${cmd}"`);
+    t.fail('should not succeed');
+  } catch (e) {
+    t.equal(countTests(e.message), 2, 'ran 2 tests');
+    t.notEqual(e.code, 0, 'exits with non-zero status code');
+    t.end();
+  }
+});
+
+test('`fusion test-app` all passing tests', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
+  const args = `test-app --dir=${dir} --configPath=../../../build/jest-config.js --match=pass`;
+
+  const cmd = `require('${runnerPath}').run('${args}')`;
+  const response = await exec(`node -e "${cmd}"`);
+  t.equal(countTests(response.stderr), 4, 'ran 4 tests');
+  t.end();
+});
+
+test('`fusion test-app` expected test passes in browser/node', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
+  const args = `test-app --dir=${dir} --configPath=../../../build/jest-config.js --match=pass-`;
+
+  const cmd = `require('${runnerPath}').run('${args}')`;
+  const response = await exec(`node -e "${cmd}"`);
+  t.equal(countTests(response.stderr), 2, 'ran 2 tests');
+
+  t.end();
+});
+
+test('`fusion test-app` expected tests fail when run in browser/node', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
+  const args = `test-app --dir=${dir} --configPath=../../../build/jest-config.js --match=fail-`;
+
+  const cmd = `require('${runnerPath}').run('${args}')`;
+  try {
+    await exec(`node -e "${cmd}"`);
+    t.fail('should not succeed');
   } catch (e) {
     t.notEqual(e.code, 0, 'exits with non-zero status code');
+    t.equal(countTests(e.message), 2, 'ran 2 tests');
     t.end();
   }
 });

--- a/test/fixtures/test-jest-app/__tests__/fail-browser.browser.js
+++ b/test/fixtures/test-jest-app/__tests__/fail-browser.browser.js
@@ -1,0 +1,5 @@
+import {test} from 'fusion-test-utils';
+
+test('Test case fails', assert => {
+  assert.equal(false, true);
+});

--- a/test/fixtures/test-jest-app/__tests__/fail-node.node.js
+++ b/test/fixtures/test-jest-app/__tests__/fail-node.node.js
@@ -1,0 +1,5 @@
+import {test} from 'fusion-test-utils';
+
+test('Test case fails', assert => {
+  assert.equal(true, false);
+});

--- a/test/fixtures/test-jest-app/__tests__/pass-browser.browser.js
+++ b/test/fixtures/test-jest-app/__tests__/pass-browser.browser.js
@@ -1,0 +1,5 @@
+import {test} from 'fusion-test-utils';
+
+test('Test case passes', assert => {
+  assert.equal(__BROWSER__, true);
+});

--- a/test/fixtures/test-jest-app/__tests__/pass-node.node.js
+++ b/test/fixtures/test-jest-app/__tests__/pass-node.node.js
@@ -1,0 +1,5 @@
+import {test} from 'fusion-test-utils';
+
+test('Test case passes', assert => {
+  assert.equal(__NODE__, true);
+});

--- a/test/fixtures/test-jest-app/count-tests.js
+++ b/test/fixtures/test-jest-app/count-tests.js
@@ -1,0 +1,15 @@
+module.exports = function (output) {
+  // Parse jest output like:
+  // Test Suites: 1 failed, 1 total
+  const pattern = /Test Suites:.*?, ([0-9]+) total/g;
+  let match;
+  let total = 0;
+
+  do {
+    match = pattern.exec(output);
+    if (match) {
+      total += parseInt(match[1], 10);
+    }
+  } while (match);
+  return total;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2841,9 +2841,9 @@ fusion-core@^0.1.8:
     koa-compose "^4.0.0"
     node-mocks-http "^1.6.6"
 
-fusion-test-utils@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/fusion-test-utils/-/fusion-test-utils-0.2.3.tgz#acf617512dd42206ede8689942a19885e2e7fa0d"
+fusion-test-utils@0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/fusion-test-utils/-/fusion-test-utils-0.2.4.tgz#cde093be74ed3a9eb4dfa6423adc21616838c428"
   dependencies:
     assert "^1.4.1"
     koa "^2.4.1"


### PR DESCRIPTION
This preserves the universal/node/browser convention that we had previously established.

Fixes #68