### PR TITLE
Add optional .fusionrc.js with babel field for custom plugins/presets

### DIFF
--- a/build/load-fusionrc.js
+++ b/build/load-fusionrc.js
@@ -1,0 +1,27 @@
+/* eslint-env node */
+
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function validateConfig(dir) {
+  const configPath = path.join(dir, '.fusionrc.js');
+  let config;
+  if (fs.existsSync(configPath)) {
+    config = require(configPath);
+    if (!isValid(config)) {
+      throw new Error('.fusionrc.js is invalid');
+    }
+  } else {
+    config = {};
+  }
+  return config;
+};
+
+function isValid(config) {
+  return (
+    typeof config === 'object' &&
+    Object.keys(config).every(el => ['babel'].includes(el)) &&
+    config.babel &&
+    Object.keys(config.babel).every(el => ['plugins', 'presets'].includes(el))
+  );
+}

--- a/test/compiler/api.js
+++ b/test/compiler/api.js
@@ -112,6 +112,50 @@ test('dev works', async t => {
   }
 });
 
+test('compiles with babel plugin', async t => {
+  const envs = ['development'];
+  const dir = './test/fixtures/custom-babel';
+  const serverEntryPath = path.resolve(
+    dir,
+    `.fusion/dist/${envs[0]}/server/server-main.js`
+  );
+  const clientEntryPath = path.resolve(
+    dir,
+    `.fusion/dist/${envs[0]}/client/client-main.js`
+  );
+
+  const compiler = new Compiler({envs, dir});
+  await compiler.clean();
+
+  const watcher = await new Promise((resolve, reject) => {
+    const watcher = compiler.start((err, stats) => {
+      if (err || stats.hasErrors()) {
+        return reject(err || new Error('Compiler stats included errors.'));
+      }
+
+      return resolve(watcher);
+    });
+  });
+  watcher.close();
+
+  t.ok(fs.existsSync(clientEntryPath), 'Client file gets compiled');
+  t.ok(fs.existsSync(serverEntryPath), 'Server file gets compiled');
+
+  const clientEntry = fs.readFileSync(clientEntryPath, 'utf8');
+  const serverEntry = fs.readFileSync(serverEntryPath, 'utf8');
+
+  t.ok(
+    clientEntry.includes('transformed_helloworld_custom_babel'),
+    'custom plugin applied in client'
+  );
+  t.ok(
+    serverEntry.includes('transformed_helloworld_custom_babel'),
+    'custom plugin applied in server'
+  );
+
+  t.end();
+});
+
 test('production works', async t => {
   const envs = ['production'];
   const dir = './test/fixtures/noop';

--- a/test/fixtures/custom-babel/.fusionrc.js
+++ b/test/fixtures/custom-babel/.fusionrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  babel: {
+    plugins: [require.resolve('./plugin.js')]
+  }
+};

--- a/test/fixtures/custom-babel/plugin.js
+++ b/test/fixtures/custom-babel/plugin.js
@@ -1,0 +1,9 @@
+module.exports = () => ({
+  visitor: {
+    StringLiteral(path) {
+      if (path.node.value === "helloworld") {
+        path.node.value = "transformed_helloworld_custom_babel";
+      }
+    }
+  }
+});

--- a/test/fixtures/custom-babel/src/main.js
+++ b/test/fixtures/custom-babel/src/main.js
@@ -1,0 +1,8 @@
+console.log('helloworld');
+
+export default async function() {
+  return {
+    plugins: [],
+    callback() {},
+  };
+}


### PR DESCRIPTION
Resolves https://github.com/fusionjs/fusion-cli/issues/77

### Why not `.babelrc`?

- We want `{babelrc: false}` so nested configuration isn't read (i.e. in `node_modules`). This behavior will probably be removed from babel 7, but in the meantime this is important.
- `.babelrc` isn't meant for extension, it's meant to be the full source of truth. But we don't want people to need to explicitly extend from our config (which would be hard in the first place since we dynamically create lots of babel configuration).