### PR TITLE
Add enzyme snapshot serializer

### DIFF
--- a/build/jest-config.js
+++ b/build/jest-config.js
@@ -2,15 +2,16 @@
 
 module.exports = {
   cache: true,
-  rootDir: process.cwd(),
   globals: {
     __NODE__: process.env.JEST_ENV === 'node',
     __BROWSER__: process.env.JEST_ENV === 'jsdom',
   },
+  rootDir: process.cwd(),
   setupFiles: [
     require.resolve('./jest-framework-shims.js'),
     require.resolve('./jest-framework-setup.js'),
   ],
+  snapshotSerializers: [require.resolve('enzyme-to-json/serializer')],
   testPathIgnorePatterns: [
     process.env.JEST_ENV === 'node' ? '.*\\.browser\\.js' : '.*\\.node\\.js',
   ],

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "core-js": "^2.5.1",
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.1.0",
+    "enzyme-to-json": "^3.3.0",
     "es6-object-assign": "^1.1.0",
     "express": "^4.15.2",
     "fast-async": "^6.3.0",

--- a/test/cli/test-app.js
+++ b/test/cli/test-app.js
@@ -103,6 +103,38 @@ test('`fusion test-app` snapshotting', async t => {
   t.end();
 });
 
+test('`fusion test-app` snapshotting - enzyme serializer', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
+  const args = `test-app --dir=${dir} --configPath=../../../build/jest-config.js --match=snapshot-enzyme-no-match`;
+
+  const snapshotFile =
+    __dirname +
+    '/../fixtures/test-jest-app/__tests__/__snapshots__/snapshot-enzyme-no-match.js.snap';
+  const backupSnapshot =
+    __dirname + '/../fixtures/snapshots/snapshot-enzyme-no-match.js.snap';
+
+  const cmd = `require('${runnerPath}').run('${args}')`;
+  try {
+    await exec(`node -e "${cmd}"`);
+    t.fail('should not succeed');
+  } catch (e) {
+    t.notEqual(e.code, 0, 'exits with non-zero status code');
+    t.equal(countTests(e.message), 2, 'ran 2 tests');
+  }
+
+  const updateSnapshot = `require('${runnerPath}').run('${args} --updateSnapshot')`;
+  await exec(`node -e "${updateSnapshot}"`);
+
+  const newSnapshotCode = fs.readFileSync(snapshotFile);
+  const originalSnapshotCode = fs.readFileSync(backupSnapshot);
+  t.notEqual(newSnapshotCode, originalSnapshotCode, 'snapshot is updated');
+
+  // Restore the failing snapshot
+  fs.createReadStream(backupSnapshot).pipe(fs.createWriteStream(snapshotFile));
+
+  t.end();
+});
+
 test('`fusion test-app` dynamic imports', async t => {
   const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
   const args = `test-app --dir=${dir} --configPath=../../../build/jest-config.js --match=dynamic-imports`;

--- a/test/fixtures/snapshots/snapshot-enzyme-no-match.js.snap
+++ b/test/fixtures/snapshots/snapshot-enzyme-no-match.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Enzyme wrapper snapshotting 1`] = `<div />`;

--- a/test/fixtures/test-jest-app/__tests__/__snapshots__/snapshot-enzyme-no-match.js.snap
+++ b/test/fixtures/test-jest-app/__tests__/__snapshots__/snapshot-enzyme-no-match.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Enzyme wrapper snapshotting 1`] = `<div />`;

--- a/test/fixtures/test-jest-app/__tests__/snapshot-enzyme-no-match.js
+++ b/test/fixtures/test-jest-app/__tests__/snapshot-enzyme-no-match.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {test} from 'fusion-test-utils';
+
+test('Enzyme wrapper snapshotting', assert => {
+  const wrapper = shallow(<div data-should-fail />);
+  assert.matchSnapshot(wrapper);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,6 +2100,12 @@ enzyme-adapter-utils@^1.1.0:
     object.assign "^4.0.4"
     prop-types "^15.5.10"
 
+enzyme-to-json@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.3.0.tgz#553e23a09ffb4b0cf09287e2edf9c6539fddaa84"
+  dependencies:
+    lodash "^4.17.4"
+
 enzyme@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/enzyme/-/enzyme-3.2.0.tgz#998bdcda0fc71b8764a0017f7cc692c943f54a7a"


### PR DESCRIPTION
This will allow for snapshot serialization with shallow wrappers by default. The library falls back to a solution which also works with React wrappers, but IMO we should encourage people to use shallow rendering where possible.

The test cases become quite elegant:
```js
test('Test case', assert => {
  const wrapper = shallow(<div />);
  assert.matchSnapshot(wrapper);
});
```

Fixes #68 
