### PR TITLE
Optimize docker layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM node:8.9.0
 
 WORKDIR /fusion-cli
 
-COPY package.json yarn.lock /fusion-cli/
-
 RUN apt-get update && apt-get install -y wget --no-install-recommends \
   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
@@ -12,5 +10,7 @@ RUN apt-get update && apt-get install -y wget --no-install-recommends \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /src/*.deb
+
+COPY package.json yarn.lock /fusion-cli/
 
 RUN yarn


### PR DESCRIPTION
Package.json contents will change more often than apt dependencies, so attempt to optimize for caching by installing apt dependencies first.
  
Fixes #115