### PR TITLE
Merge jsdom and node coverage results

### DIFF
--- a/build/jest-config.js
+++ b/build/jest-config.js
@@ -9,7 +9,9 @@ module.exports = {
     __BROWSER__: process.env.JEST_ENV === 'jsdom',
     __DEV__: process.env.NODE_ENV !== 'production',
   },
-  coverageReporters: ['json', 'lcov', 'text', 'cobertura'],
+  coverageDirectory: `<rootDir>/coverage-${process.env.JEST_ENV}`,
+  // 'cobertura', 'lcov', 'text' coverage reports are written by the merge-coverage script
+  coverageReporters: ['json'],
   rootDir: process.cwd(),
   setupFiles: [
     require.resolve('./jest-framework-shims.js'),

--- a/build/merge-coverage.js
+++ b/build/merge-coverage.js
@@ -1,0 +1,46 @@
+/* eslint-env node */
+const fs = require('fs');
+
+// Jest writes coverage after the process exits
+// so we need to poll and wait for all coverage files.
+const waitForAllCoverage = config => {
+  return Promise.all(
+    config.environments.map(
+      env =>
+        new Promise(resolve => {
+          const interval = setInterval(() => {
+            const coverageExists = fs.existsSync(
+              `${config.dir}/coverage-${env}/coverage-final.json`
+            );
+            if (coverageExists) {
+              resolve();
+              clearInterval(interval);
+            }
+          }, 100);
+        })
+    )
+  );
+};
+
+module.exports = function(config) {
+  return waitForAllCoverage(config).then(() => {
+    const createReporter = require('istanbul-api').createReporter;
+    const istanbulCoverage = require('istanbul-lib-coverage');
+
+    const map = istanbulCoverage.createCoverageMap();
+    const reporter = createReporter();
+
+    config.environments.forEach(env => {
+      const coverage = require(`${
+        config.dir
+      }/coverage-${env}/coverage-final.json`);
+      Object.keys(coverage).forEach(filename =>
+        map.addFileCoverage(coverage[filename])
+      );
+    });
+
+    reporter.dir = `${config.dir}/coverage`;
+    reporter.addAll(['json', 'lcov', 'text', 'cobertura']);
+    reporter.write(map);
+  });
+};

--- a/build/merge-coverage.js
+++ b/build/merge-coverage.js
@@ -4,17 +4,23 @@ const fs = require('fs');
 // Jest writes coverage after the process exits
 // so we need to poll and wait for all coverage files.
 const waitForAllCoverage = config => {
+  const maxTries = 10000;
+  let numTries = 0;
   return Promise.all(
     config.environments.map(
       env =>
-        new Promise(resolve => {
+        new Promise((resolve, reject) => {
           const interval = setInterval(() => {
             const coverageExists = fs.existsSync(
               `${config.dir}/coverage-${env}/coverage-final.json`
             );
+            numTries += 1;
             if (coverageExists) {
-              resolve();
               clearInterval(interval);
+              resolve();
+            } else if (numTries > maxTries) {
+              clearInterval(interval);
+              reject();
             }
           }, 100);
         })

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "iltorb": "^2.0.3",
     "imagemin": "^5.3.1",
     "imagemin-svgo": "^6.0.0",
+    "istanbul-api": "^1.2.1",
+    "istanbul-lib-coverage": "^1.1.1",
     "jest": "^22.0.4",
     "jest-cli": "^22.0.4",
     "just-snake-case": "^1.0.0",

--- a/test/fixtures/test-jest-app/.gitignore
+++ b/test/fixtures/test-jest-app/.gitignore
@@ -1,1 +1,1 @@
-coverage/
+coverage*/

--- a/yarn.lock
+++ b/yarn.lock
@@ -4037,7 +4037,7 @@ isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-api@^1.1.14:
+istanbul-api@^1.1.14, istanbul-api@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.2.1.tgz#0c60a0515eb11c7d65c6b50bba2c6e999acd8620"
   dependencies:


### PR DESCRIPTION
This creates multiple coverage folders depending on what test suites are run (node, jsdom), and merges them after coverage is collected into a single coverage/ folder. There is some weirdness around the jest process exiting before coverage is done writing to disk, so we wait until expected coverage files are present before merging.

Fixes #121
