### PR TITLE
Add debug flag and fix browser bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,30 +12,31 @@ yarn add fusion-cli
 
 ### CLI API
 
-- `fusion build [dir] [--test] [--cover] [--production] [--log-level]`: Build your appplication
-  - `--test`: Build tests as well as application
-  - `--cover`: Build tests (with coverage) as well as application
-  - `--production`: Build production assets
-  - `--log-level`: Log level to output to console `[default: "info"]`
-- `fusion dev [dir] [--port] [--no-hmr] [--test] [--cover] [--log-level]`: Run your application in development
-  - `--port`: The port on which the application runs `[default: 3000]`
-  - `--no-hmr`: Run without hot modules replacement
-  - `--test`: Run tests as well as application
-  - `--cover`: Run tests (with coverage) as well as application
-  - `--log-level`: Log level to output to console `[default: "info"]`
-- `fusion profile [--environment] [--watch] [--file-count]`: Profile your application
-  - `--environment`: Either `production` or `development` `[default: "production"]`
-  - `--watch`: After profiling, launch source-map-explorer with file watch
-  - `--file-count`: The number of file sizes to output, sorted largest to smallest (-1 for all files) `[default: 20]`
-- `fusion start [--environment]`: Run your application
-  - `--environment`: Which environment/assets to run - defaults to first available assets among `["development", "test", "production"]`
-- `fusion test [--cover] [--watch] [--skip-build]`: Run tests
-  - `--cover`: Run tests with coverage
-  - `--watch`: Automatically re-profile your application on changes
-  - `--skip-build`: Use existing built assets
-- `fusion test-app [--watch] [--match]`: Run tests
-  - `--watch`: Automatically run tests when code changes.
-  - `--match="somestring"`: Only runs tests against files which match this string.
-  - `--coverage`: Collects and outputs test coverage
-  - `--env`: Which environments to run tests in. Defaults to "node,jsdom". You may specify only one.
-  - `--updateSnapshot`: Updates snapshots
+* `fusion build [dir] [--test] [--cover] [--production] [--log-level]`: Build your appplication
+  * `--test`: Build tests as well as application
+  * `--cover`: Build tests (with coverage) as well as application
+  * `--production`: Build production assets
+  * `--log-level`: Log level to output to console `[default: "info"]`
+* `fusion dev [dir] [--port] [--no-hmr] [--test] [--cover] [--log-level]`: Run your application in development
+  * `--port`: The port on which the application runs `[default: 3000]`
+  * `--no-hmr`: Run without hot modules replacement
+  * `--test`: Run tests as well as application
+  * `--cover`: Run tests (with coverage) as well as application
+  * `--log-level`: Log level to output to console `[default: "info"]`
+* `fusion profile [--environment] [--watch] [--file-count]`: Profile your application
+  * `--environment`: Either `production` or `development` `[default: "production"]`
+  * `--watch`: After profiling, launch source-map-explorer with file watch
+  * `--file-count`: The number of file sizes to output, sorted largest to smallest (-1 for all files) `[default: 20]`
+* `fusion start [--environment]`: Run your application
+  * `--environment`: Which environment/assets to run - defaults to first available assets among `["development", "test", "production"]`
+* `fusion test [--cover] [--watch] [--skip-build]`: Run tests
+  * `--cover`: Run tests with coverage
+  * `--watch`: Automatically re-profile your application on changes
+  * `--skip-build`: Use existing built assets
+* `fusion test-app [--watch] [--match]`: Run tests
+  * `--watch`: Automatically run tests when code changes.
+  * `--match="somestring"`: Only runs tests against files which match this string.
+  * `--coverage`: Collects and outputs test coverage
+  * `--env`: Which environments to run tests in. Defaults to "node,jsdom". You may specify only one.
+  * `--debug`: Allows you to debug tests using the chrome inspector (chrome://inspect).
+  * `--updateSnapshot`: Updates snapshots

--- a/build/jest-config.js
+++ b/build/jest-config.js
@@ -11,6 +11,7 @@ module.exports = {
     __BROWSER__: process.env.JEST_ENV === 'jsdom',
     __DEV__: process.env.NODE_ENV !== 'production',
   },
+  browser: process.env.JEST_ENV === 'jsdom',
   coverageDirectory: `<rootDir>/coverage-${process.env.JEST_ENV}`,
   // 'cobertura', 'lcov', 'text' coverage reports are written by the merge-coverage script
   coverageReporters: ['json'],

--- a/build/test-app-runtime.js
+++ b/build/test-app-runtime.js
@@ -8,6 +8,7 @@ const mergeCoverage = require('./merge-coverage');
 module.exports.TestAppRuntime = function({
   dir = '.',
   watch = false,
+  debug = false,
   match,
   env,
   testFolder,
@@ -22,9 +23,21 @@ module.exports.TestAppRuntime = function({
     this.stop();
     const allTestEnvs = env.split(',');
     let command = require.resolve('jest-cli/bin/jest.js');
+    if (debug) {
+      command = `node`;
+    }
 
     const getArgs = () => {
-      let args = ['--config', configPath];
+      let args = [];
+      if (debug) {
+        args = args.concat([
+          '--inspect-brk',
+          require.resolve('jest/bin/jest.js'),
+          '--runInBand',
+        ]);
+      }
+
+      args = args.concat(['--config', configPath]);
 
       if (watch) {
         args.push('--watch');
@@ -78,7 +91,6 @@ module.exports.TestAppRuntime = function({
         if (allTestEnvs.length > 1 && watch) {
           procEnv.CI = 'true';
         }
-
         const proc = spawn(command, args, {
           cwd: rootDir,
           stdio: 'inherit',

--- a/build/test-app-runtime.js
+++ b/build/test-app-runtime.js
@@ -87,7 +87,6 @@ module.exports.TestAppRuntime = function({
         if (allTestEnvs.length > 1 && watch) {
           procEnv.CI = 'true';
         }
-        console.log('args are?', args);
         const proc = spawn('node', args, {
           cwd: rootDir,
           stdio: 'inherit',

--- a/commands/test-app.js
+++ b/commands/test-app.js
@@ -8,6 +8,11 @@ exports.builder = {
     default: '.',
     describe: 'Root path for the application relative to CLI CWD',
   },
+  debug: {
+    type: 'boolean',
+    default: false,
+    describe: 'Debug tests',
+  },
   watch: {
     type: 'boolean',
     default: false,
@@ -49,6 +54,7 @@ exports.builder = {
 exports.run = async function({
   dir = '.',
   watch,
+  debug,
   match,
   env,
   testFolder,
@@ -59,6 +65,7 @@ exports.run = async function({
   const testRuntime = new TestAppRuntime({
     dir,
     watch,
+    debug,
     match,
     env,
     testFolder,

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   },
   "devDependencies": {
     "babel-eslint": "8.2.1",
+    "chrome-remote-interface": "^0.25.5",
     "enzyme": "3.3.0",
     "eslint": "4.16.0",
     "eslint-config-fusion": "0.2.1",

--- a/test/cli/test-app.js
+++ b/test/cli/test-app.js
@@ -4,8 +4,10 @@ const fs = require('fs');
 const path = require('path');
 const test = require('tape');
 
+const CDP = require('chrome-remote-interface');
 const {promisify} = require('util');
 const exec = promisify(require('child_process').exec);
+const spawn = require('child_process').spawn;
 
 const readFile = promisify(fs.readFile);
 
@@ -224,4 +226,66 @@ test('`fusion test-app` uses .fusionjs.js', async t => {
   t.equal(countTests(response.stderr), 2, 'ran 2 tests');
 
   t.end();
+});
+
+async function triggerCodeStep() {
+  return new Promise(resolve => {
+    CDP({port: '9229'}, async client => {
+      const {Runtime} = client;
+      await Runtime.runIfWaitingForDebugger();
+      await client.close();
+      resolve();
+    }).on('error', err => {
+      throw err;
+    });
+  });
+}
+
+test('`fusion test-app --debug --env=jsdom,node`', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
+  const args = `test-app --dir=${dir} --configPath=../../../build/jest-config.js --debug --env=jsdom,node  --match=passes`;
+
+  const cmd = `require('${runnerPath}').run('${args}')`;
+  const stderrLines = [];
+  const child = spawn('node', ['-e', cmd]);
+
+  const listenAddresses = {};
+  let numResults = 0;
+  child.stderr &&
+    child.stderr.on('data', data => {
+      const line = data.toString();
+      stderrLines.push(line);
+      // Keep track of all addresses that we start listening to.
+      if (line.startsWith('Debugger listening on ws')) {
+        listenAddresses[line] = true;
+      }
+
+      // Wait until we have results for both environments before ending the test.
+      if (/Tests:.*1\s+passed,\s+1\s+total/.test(line)) {
+        numResults += 1;
+        if (numResults == 2) {
+          t.end();
+        }
+      }
+    });
+
+  // Poll until we get a listener message.
+  async function checkStartedMessageCount(count) {
+    return new Promise(async resolve => {
+      while (Object.keys(listenAddresses).length < count) {
+        await new Promise(r => setTimeout(r, 100));
+      }
+      resolve();
+    });
+  }
+
+  // Step through jsdom environment
+  await checkStartedMessageCount(1);
+  await triggerCodeStep();
+
+  // Step through node environment
+  await checkStartedMessageCount(2);
+  await triggerCodeStep();
+
+  child.kill();
 });

--- a/test/cli/test-app.js
+++ b/test/cli/test-app.js
@@ -287,5 +287,11 @@ test('`fusion test-app --debug --env=jsdom,node`', async t => {
   await checkStartedMessageCount(2);
   await triggerCodeStep();
 
+  t.equal(
+    Object.keys(listenAddresses).length,
+    2,
+    'listened for two remote debug connections'
+  );
+
   child.kill();
 });


### PR DESCRIPTION
* Fix browser bundling by setting browser: true when in a browser environment.
* Add a --debug flag so we can step through code with chrome://inspect.
* Add a unit test which exercises the debug flag and validates that we can connect to the debugger.