### PR TITLE
Fix assetUrl when used outside of app lifecycle

### DIFF
--- a/entries/server-entry.js
+++ b/entries/server-entry.js
@@ -29,7 +29,8 @@ into `__webpack_require__.p = ...` and uses it for HMR manifest requests
 // eslint-disable-next-line
 __webpack_public_path__ = getCompilationMetaData().webpackPublicPath + '/';
 
-// The shared entry must be imported after setting __webpack_public_path__
+// The shared entry must be imported after setting __webpack_public_path__.
+// We use a require as imports are hoisted and would be run before setting __webpack_public_path__.
 // eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies
 const main = require('__FRAMEWORK_SHARED_ENTRY__');
 

--- a/entries/server-entry.js
+++ b/entries/server-entry.js
@@ -1,7 +1,5 @@
 /* eslint-env node */
 import http from 'http';
-// eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies
-import main from '__FRAMEWORK_SHARED_ENTRY__';
 import getCompilationMetaData from '../plugins/compilation-metadata-plugin';
 import AssetsFactory from '../plugins/assets-plugin';
 import ContextPlugin from '../plugins/context-plugin';
@@ -30,6 +28,10 @@ into `__webpack_require__.p = ...` and uses it for HMR manifest requests
 */
 // eslint-disable-next-line
 __webpack_public_path__ = getCompilationMetaData().webpackPublicPath + '/';
+
+// The shared entry must be imported after setting __webpack_public_path__
+// eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies
+const main = require('__FRAMEWORK_SHARED_ENTRY__');
 
 const state = {serve: null};
 const initialize = main

--- a/test/cli/dev.js
+++ b/test/cli/dev.js
@@ -49,6 +49,10 @@ test('`fusion dev` works with assets', async t => {
     );
     t.equal(await request(`http://localhost:${port}/dirname`), 'src');
     t.equal(await request(`http://localhost:${port}/filename`), 'src/main.js');
+    t.equal(
+      await request(`http://localhost:${port}/hoisted`),
+      expectedAssetPath
+    );
   } catch (e) {
     t.iferror(e);
   }

--- a/test/fixtures/assets/src/main.js
+++ b/test/fixtures/assets/src/main.js
@@ -1,21 +1,27 @@
 import App from 'fusion-core';
 import {assetUrl} from 'fusion-core';
+
+const hoistedUrl = assetUrl('./static/test.css');
+
 export default async function() {
   const app = new App('element', el => el);
-  __NODE__ && app.middleware((ctx, next) => {
-    if (ctx.url.startsWith('/_static')) {
-      ctx.set('x-test', 'test');
-    } else if (ctx.url === '/test') {
-      ctx.body = assetUrl('./static/test.css');
-    } else if (ctx.url === '/dirname') {
-      ctx.body = __dirname;
-    } else if (ctx.url === '/filename') {
-      ctx.body = __filename;
-    }
-    
-    __BROWSER__ && console.log('Dirname is', __dirname);
-    __BROWSER__ && console.log('Filename is', __filename);
-    return next();
-  });
+  __NODE__ &&
+    app.middleware((ctx, next) => {
+      if (ctx.url.startsWith('/_static')) {
+        ctx.set('x-test', 'test');
+      } else if (ctx.url === '/test') {
+        ctx.body = assetUrl('./static/test.css');
+      } else if (ctx.url === '/dirname') {
+        ctx.body = __dirname;
+      } else if (ctx.url === '/filename') {
+        ctx.body = __filename;
+      } else if (ctx.url === '/hoisted') {
+        ctx.body = hoistedUrl;
+      }
+
+      __BROWSER__ && console.log('Dirname is', __dirname);
+      __BROWSER__ && console.log('Filename is', __filename);
+      return next();
+    });
   return app;
 }


### PR DESCRIPTION
Previously we were creating invalid assetUrls because `__webpack_public_path__` was not set yet. Work around this by reordering the the shared entry to be after the public path assignment.

Fixes #228