### PR TITLE
Pin enzyme-to-json@3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "compression-webpack-plugin": "^1.1.7",
     "core-js": "^2.5.3",
     "enzyme-adapter-react-16": "^1.1.1",
-    "enzyme-to-json": "^3.3.1",
+    "enzyme-to-json": "3.3.1",
     "es6-object-assign": "^1.1.0",
     "express": "^4.16.2",
     "fast-async": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,9 +2437,9 @@ enzyme-adapter-utils@^1.3.0:
     object.assign "^4.0.4"
     prop-types "^15.6.0"
 
-enzyme-to-json@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.2.tgz#5caf0b3729ffea3aa14702f12c37e93b501a9d96"
+enzyme-to-json@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.1.tgz#64239dcd417e2fb552f4baa6632de4744b9b5b93"
   dependencies:
     lodash "^4.17.4"
 


### PR DESCRIPTION
Version 3.3.2 was published to the npm registry briefly before being unpublished. Unfortunately some references remain in registries, and running yarn add enzyme-to-json@^3.3.1 will cause yarn to error. We can temporarily pin the version to get around this, and I've also filed https://github.com/adriantoine/enzyme-to-json/issues/100 in the meantime.

Example error message: `error An unexpected error occurred: "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.2.tgz: Request failed \"404 Not Found\""`