### PR TITLE
Add dynamic import test

### DIFF
--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -251,7 +251,12 @@ test('`fusion build` with dynamic imports', async t => {
   const entry = path.resolve(dir, entryPath);
   const command = `require('${entry}');`;
   const {stdout} = await run(command, {stdio: 'pipe'});
-  t.ok(stdout.includes('loaded dynamic import'), 'dynamic import is executed');
+  const testContent = JSON.parse(stdout);
+  t.ok(
+    testContent.dynamicContent.includes('loaded dynamic import'),
+    'dynamic import is executed'
+  );
+  t.deepEqual(testContent.chunkIds, [[1], [0]], 'Chunk IDs are populated');
 
   t.ok(
     await exists(path.resolve(dir, `.fusion/dist/development/client/0.js`)),

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const test = require('tape');
-const {cmd, start} = require('../run-command');
+const {cmd, run, start} = require('../run-command');
 const {promisify} = require('util');
 const request = require('request-promise');
 
@@ -239,5 +239,27 @@ test('`fusion build` with assets', async t => {
   } catch (e) {
     t.ifError(e);
   }
+  t.end();
+});
+
+test('`fusion build` with dynamic imports', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/dynamic-import');
+  await cmd(`build --dir=${dir}`);
+
+  // Execute node script to validate dynamic imports
+  const entryPath = `.fusion/dist/development/server/server-main.js`;
+  const entry = path.resolve(dir, entryPath);
+  const command = `require('${entry}');`;
+  const {stdout} = await run(command, {stdio: 'pipe'});
+  t.ok(stdout.includes('loaded dynamic import'), 'dynamic import is executed');
+
+  t.ok(
+    await exists(path.resolve(dir, `.fusion/dist/development/client/0.js`)),
+    'client dynamic import bundle exists'
+  );
+  t.ok(
+    await exists(path.resolve(dir, `.fusion/dist/development/server/0.js`)),
+    'server dynamic import bundle exists'
+  );
   t.end();
 });

--- a/test/fixtures/dynamic-import/src/dynamic.js
+++ b/test/fixtures/dynamic-import/src/dynamic.js
@@ -1,0 +1,3 @@
+export default function() {
+  return 'loaded dynamic import';
+}

--- a/test/fixtures/dynamic-import/src/dynamic2.js
+++ b/test/fixtures/dynamic-import/src/dynamic2.js
@@ -1,0 +1,1 @@
+export default function() {}

--- a/test/fixtures/dynamic-import/src/main.js
+++ b/test/fixtures/dynamic-import/src/main.js
@@ -1,6 +1,13 @@
 export default function main() {
-  return import('./dynamic.js').then(dynamicImport =>
-    console.log(dynamicImport.default())
+  const loader2 = import('./dynamic2.js');
+  const loader = import('./dynamic.js');
+  loader.then(dynamicImport =>
+    console.log(
+      JSON.stringify({
+        dynamicContent: dynamicImport.default(),
+        chunkIds: [loader.__CHUNK_IDS, loader2.__CHUNK_IDS],
+      })
+    )
   );
 }
 

--- a/test/fixtures/dynamic-import/src/main.js
+++ b/test/fixtures/dynamic-import/src/main.js
@@ -1,0 +1,7 @@
+export default function main() {
+  return import('./dynamic.js').then(dynamicImport =>
+    console.log(dynamicImport.default())
+  );
+}
+
+main();


### PR DESCRIPTION
Currently there is no test case that exercises our dynamic import logic. This will ensure that we have some coverage for this functionality as we migrate to webpack 4.