### PR TITLE
Add named default async export test case

### DIFF
--- a/test/cli/dev.js
+++ b/test/cli/dev.js
@@ -197,3 +197,12 @@ test('`fusion dev` recovering from errors', async t => {
   });
   fs.writeFileSync(mainPath, fs.readFileSync(mainPath));
 });
+
+test('`fusion dev` with named async function', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/named-async-main');
+  const {proc} = await dev(`--dir=${dir}`, {
+    stdio: 'inherit',
+  });
+  proc.kill();
+  t.end();
+});

--- a/test/fixtures/named-async-main/src/main.js
+++ b/test/fixtures/named-async-main/src/main.js
@@ -1,0 +1,5 @@
+import App from 'fusion-core';
+export default async function start() {
+  const app = new App('element', el => el);
+  return app;
+}


### PR DESCRIPTION
Adds a test case that currently breaks:

![image](https://user-images.githubusercontent.com/122602/37494109-b017969e-2864-11e8-8203-f576840f3578.png)

To test this out in a CLI:
```
node /Users/keving/Uber/fusionjs/fusion-cli/bin/cli.js dev --port=63840 --no-open --dir=/Users/keving/Uber/fusionjs/fusion-cli/test/fixtures/named-async-main
```