### PR TITLE
Remove react-hot-loader and add HMR test

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*/node_modules/.*[^(package)]\.json$
+.*/.fusion/
 
 [include]
 

--- a/build/compiler.js
+++ b/build/compiler.js
@@ -241,10 +241,6 @@ function getConfig({target, env, dir, watch, cover}) {
                     require.resolve('@babel/plugin-transform-react-jsx'),
                     {pragma},
                   ],
-                  env === 'development' &&
-                    watch &&
-                    target === 'web' &&
-                    require.resolve('react-hot-loader/babel'),
                   cover && require.resolve('babel-plugin-istanbul'),
                   target === 'node' &&
                     require.resolve('./babel-plugins/babel-plugin-i18n'),

--- a/flow-typed/globals.js
+++ b/flow-typed/globals.js
@@ -1,0 +1,4 @@
+// @flow
+
+declare var __NODE__: boolean;
+declare var __BROWSER__: boolean;

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "range-parser": "^1.2.0",
     "react-dev-utils": "^5.0.0",
     "react-error-overlay": "^4.0.0",
-    "react-hot-loader": "^4.0.0",
     "redbox-react": "^1.5.0",
     "request": "^2.85.0",
     "resolve-from": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "fusion-tokens": "^1.0.2",
     "globby": "8.0.1",
     "prettier": "1.11.1",
+    "puppeteer": "^1.2.0",
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "react-test-renderer": "16.2.0",

--- a/test/fixtures/hmr-simple-app/src/home.js
+++ b/test/fixtures/hmr-simple-app/src/home.js
@@ -1,0 +1,7 @@
+// @flow
+
+import React from 'react';
+
+export default function() {
+  return <div className="hmr-class-default">hmr-component-default</div>;
+}

--- a/test/fixtures/hmr-simple-app/src/main.js
+++ b/test/fixtures/hmr-simple-app/src/main.js
@@ -1,0 +1,10 @@
+// @flow
+import React from 'react';
+import App from 'fusion-react';
+
+import home from './home.js';
+
+export default async function start() {
+  const app = new App(home());
+  return app;
+}

--- a/test/fixtures/hmr-with-router/src/home.js
+++ b/test/fixtures/hmr-with-router/src/home.js
@@ -1,0 +1,7 @@
+// @flow
+
+import React from 'react';
+
+export default function() {
+  return <div className="hmr-class-default">hmr-component-default</div>;
+}

--- a/test/fixtures/hmr-with-router/src/main.js
+++ b/test/fixtures/hmr-with-router/src/main.js
@@ -1,0 +1,24 @@
+// @flow
+import React from 'react';
+import App from 'fusion-react';
+import Router, {Route, Switch} from 'fusion-plugin-react-router';
+import UniversalEvents, {
+  UniversalEventsToken,
+} from 'fusion-plugin-universal-events';
+import {FetchToken} from 'fusion-tokens';
+
+import home from './home.js';
+
+export default async function start() {
+  const app = new App(
+    (
+      <Switch>
+        <Route exact path="/" component={home} />
+      </Switch>
+    )
+  );
+  app.register(Router, {});
+  app.register(UniversalEventsToken, UniversalEvents);
+  __BROWSER__ && app.register(FetchToken, fetch);
+  return app;
+}

--- a/test/hmr.js
+++ b/test/hmr.js
@@ -1,0 +1,59 @@
+// @flow
+/* eslint-env node */
+const fs = require('fs');
+const path = require('path');
+const test = require('tape');
+const puppeteer = require('puppeteer');
+const {dev} = require('./run-command');
+
+async function testHmr(app, t) {
+  const dir = path.resolve(__dirname, `fixtures/${app}`);
+  const {proc, port} = await dev(`--dir=${dir}`);
+
+  const fixtureContent = fs.readFileSync(
+    path.resolve(dir, 'src/home.js'),
+    'utf-8'
+  );
+
+  // Replace main.js content, simulating a file edit.
+  const updatedContent = fixtureContent
+    .replace('hmr-component-default', 'hmr-component-replaced')
+    .replace('hmr-class-default', 'hmr-class-replaced');
+
+  // Launch the browser and load the page.
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const page = await browser.newPage();
+  await page.goto(`http://localhost:${port}/`);
+
+  const content = await page.content();
+  t.ok(
+    content.includes('hmr-component-default'),
+    'default app content contains hmr-component-default'
+  );
+
+  // Assert the on-page content has been updated after HMR.
+  fs.writeFileSync(path.resolve(dir, 'src/home.js'), updatedContent);
+  await page.waitFor('.hmr-class-replaced');
+
+  const newContent = await page.content();
+  t.ok(
+    newContent.includes('hmr-component-replaced'),
+    'default app content contains hmr-component-replaced'
+  );
+
+  // Restore content
+  fs.writeFileSync(path.resolve(dir, 'src/home.js'), fixtureContent);
+
+  await browser.close();
+  proc.kill();
+}
+
+test('hmr without router', async t => {
+  const testDirs = ['hmr-simple-app', 'hmr-with-router'];
+  for (let i = 0; i < testDirs.length; i++) {
+    await testHmr(testDirs[i], t);
+  }
+  t.end();
+});

--- a/test/hmr.js
+++ b/test/hmr.js
@@ -50,7 +50,7 @@ async function testHmr(app, t) {
   proc.kill();
 }
 
-test('hmr without router', async t => {
+test('test hmr across multiple fixtures', async t => {
   const testDirs = ['hmr-simple-app', 'hmr-with-router'];
   for (let i = 0; i < testDirs.length; i++) {
     await testHmr(testDirs[i], t);

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ require('./cli/test');
 require('./cli/build');
 require('./compiler/api');
 require('./compiler/errors');
+require('./hmr');
 require('./route-prefix.js');
 
 /*

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,6 +674,12 @@ address@1.0.3, address@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/address/-/address-1.0.3.tgz#b5f50631f8d6cec8bd20c963963afb55e06cbce9"
 
+agent-base@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.0.tgz#9838b5c3392b962bad031e6a4c5e1024abec45ce"
+  dependencies:
+    es6-promisify "^5.0.0"
+
 ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
@@ -1804,6 +1810,14 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
+concat-stream@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
 concat-stream@^1.5.0, concat-stream@^1.6.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.1.tgz#261b8f518301f1d834e36342b9fea095d2620a26"
@@ -2519,6 +2533,16 @@ es6-object-assign@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
 
+es6-promise@^4.0.3:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  dependencies:
+    es6-promise "^4.0.3"
+
 escape-html@~1.0.1, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -2907,6 +2931,15 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-zip@^1.6.5:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
+  dependencies:
+    concat-stream "1.6.0"
+    debug "2.6.9"
+    mkdirp "0.5.0"
+    yauzl "2.4.1"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -2982,6 +3015,12 @@ fbjs@^0.8.16:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
+
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+  dependencies:
+    pend "~1.2.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -3764,6 +3803,13 @@ http-signature@~1.2.0:
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+
+https-proxy-agent@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz#7fbba856be8cd677986f42ebd3664f6317257887"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
 
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
@@ -5476,6 +5522,12 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mkdirp@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
+  dependencies:
+    minimist "0.0.8"
+
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -6174,6 +6226,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -6332,6 +6388,10 @@ proxy-addr@~2.0.3:
     forwarded "~0.1.2"
     ipaddr.js "1.6.0"
 
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -6383,6 +6443,19 @@ punycode@^1.2.4, punycode@^1.4.1:
 punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
+
+puppeteer@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.2.0.tgz#6a8a1c618af073dfcf6fc7c7e3c12e54129ffa98"
+  dependencies:
+    debug "^2.6.8"
+    extract-zip "^1.6.5"
+    https-proxy-agent "^2.1.0"
+    mime "^1.3.4"
+    progress "^2.0.0"
+    proxy-from-env "^1.0.0"
+    rimraf "^2.6.1"
+    ws "^3.0.0"
 
 q@^1.1.2:
   version "1.5.1"
@@ -8393,7 +8466,7 @@ ws@3.3.2:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-ws@3.3.x:
+ws@3.3.x, ws@^3.0.0:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
   dependencies:
@@ -8539,3 +8612,9 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yauzl@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
+  dependencies:
+    fd-slicer "~1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2319,10 +2319,6 @@ dom-serializer@0, dom-serializer@~0.1.0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
-dom-walk@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
-
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -2982,7 +2978,7 @@ fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
-fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
+fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
@@ -3429,13 +3425,6 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
-global@^4.3.0:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
-  dependencies:
-    min-document "^2.19.0"
-    process "~0.5.1"
-
 globals@^10.0.0:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-10.4.0.tgz#5c477388b128a9e4c5c5d01c7a2aca68c68b2da7"
@@ -3685,7 +3674,7 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.3.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
@@ -5462,12 +5451,6 @@ mimic-response@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
-min-document@^2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
-  dependencies:
-    dom-walk "^0.1.0"
-
 minimalistic-assert@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
@@ -6343,10 +6326,6 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
-process@~0.5.1:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
-
 progress-bar-webpack-plugin@^1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/progress-bar-webpack-plugin/-/progress-bar-webpack-plugin-1.11.0.tgz#4f801288443c55ec029b20cbfdcbf3e1dc17f852"
@@ -6589,16 +6568,6 @@ react-dom@16.2.0:
 react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
-
-react-hot-loader@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.0.0.tgz#3452fa9bc0d0ba9dfc5b0ccfa25101ca8dbd2de2"
-  dependencies:
-    fast-levenshtein "^2.0.6"
-    global "^4.3.0"
-    hoist-non-react-statics "^2.5.0"
-    prop-types "^15.6.0"
-    shallowequal "^1.0.2"
 
 react-reconciler@^0.7.0:
   version "0.7.0"
@@ -7207,10 +7176,6 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
-
-shallowequal@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
* Remove the React hot-loader babel plugin as we perform HMR with our own logic in client-entry.js.
* Adds integration tests for hot module replacement using puppeteer.
* Add two text fixture apps for testing HMR, one with the router, and one without.

Fixes #284