### PR TITLE
Implement pure annotation for createPlugin

### DIFF
--- a/build/babel-plugins/babel-plugin-pure-create-plugin/index.js
+++ b/build/babel-plugins/babel-plugin-pure-create-plugin/index.js
@@ -1,0 +1,35 @@
+// @flow
+/* eslint-env node */
+const createNamedModuleVisitor = require('../babel-plugin-utils/visit-named-module');
+
+module.exports = pureCreatePlugin;
+
+function pureCreatePlugin(babel /*: Object */) {
+  const t = babel.types;
+  const visitor = createNamedModuleVisitor(
+    t,
+    'createPlugin',
+    'fusion-core',
+    refsHandler
+  );
+  return {visitor};
+}
+
+function refsHandler(t, context, refs = []) {
+  refs.forEach(refPath => {
+    const parentPath = refPath.parentPath;
+    if (!t.isCallExpression(parentPath)) {
+      return;
+    }
+    parentPath.addComment('leading', '#__PURE__');
+    if (parentPath.parentPath.type === 'ExportDefaultDeclaration') {
+      const id = parentPath.parentPath.scope.generateUidIdentifier('default');
+      parentPath.parentPath.insertBefore(
+        t.variableDeclaration('var', [
+          t.variableDeclarator(id, parentPath.parentPath.node.declaration),
+        ])
+      );
+      parentPath.parentPath.node.declaration = id;
+    }
+  });
+}

--- a/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/create-plugin-default-and-named
+++ b/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/create-plugin-default-and-named
@@ -1,0 +1,4 @@
+import {createPlugin} from 'fusion-core';
+
+export const p = createPlugin({});
+export default createPlugin({});

--- a/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/create-plugin-default-export
+++ b/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/create-plugin-default-export
@@ -1,0 +1,3 @@
+import {createPlugin} from 'fusion-core';
+
+export default createPlugin({});

--- a/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/create-plugin-default-multiline
+++ b/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/create-plugin-default-multiline
@@ -1,0 +1,9 @@
+import {createPlugin} from 'fusion-core';
+
+export default createPlugin({
+  deps: {
+    a: 'b',
+  },
+  provides: () => {
+  }
+});

--- a/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-and-named
+++ b/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-and-named
@@ -1,0 +1,7 @@
+import { createPlugin } from 'fusion-core';
+
+export const p = /*#__PURE__*/createPlugin({});
+
+var _default = /*#__PURE__*/createPlugin({});
+
+export default _default;

--- a/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-and-named
+++ b/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-and-named
@@ -1,7 +1,10 @@
 import { createPlugin } from 'fusion-core';
+export const p =
+/*#__PURE__*/
+createPlugin({});
 
-export const p = /*#__PURE__*/createPlugin({});
-
-var _default = /*#__PURE__*/createPlugin({});
+var _default =
+/*#__PURE__*/
+createPlugin({});
 
 export default _default;

--- a/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-export
+++ b/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-export
@@ -1,0 +1,5 @@
+import { createPlugin } from 'fusion-core';
+
+var _default = /*#__PURE__*/createPlugin({});
+
+export default _default;

--- a/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-export
+++ b/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-export
@@ -1,5 +1,7 @@
 import { createPlugin } from 'fusion-core';
 
-var _default = /*#__PURE__*/createPlugin({});
+var _default =
+/*#__PURE__*/
+createPlugin({});
 
 export default _default;

--- a/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-multiline
+++ b/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-multiline
@@ -1,0 +1,10 @@
+import { createPlugin } from 'fusion-core';
+
+var _default = /*#__PURE__*/createPlugin({
+  deps: {
+    a: 'b'
+  },
+  provides: () => {}
+});
+
+export default _default;

--- a/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-multiline
+++ b/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-multiline
@@ -1,6 +1,8 @@
 import { createPlugin } from 'fusion-core';
 
-var _default = /*#__PURE__*/createPlugin({
+var _default =
+/*#__PURE__*/
+createPlugin({
   deps: {
     a: 'b'
   },

--- a/build/babel-plugins/babel-plugin-pure-create-plugin/test/index.js
+++ b/build/babel-plugins/babel-plugin-pure-create-plugin/test/index.js
@@ -1,0 +1,37 @@
+// @flow
+/* eslint-env node */
+const fs = require('fs');
+const test = require('tape');
+const {transformFileSync} = require('babel-core');
+const plugin = require('../');
+
+function getOutput(file) {
+  return transformFileSync(__dirname + file, {
+    plugins: [plugin],
+  }).code;
+}
+
+function readExpected(file) {
+  return fs.readFileSync(__dirname + file).toString();
+}
+
+test('createPlugin default export', t => {
+  const output = getOutput('/fixtures/create-plugin-default-export');
+  const expected = readExpected('/fixtures/expected-default-export');
+  t.equal(output, expected);
+  t.end();
+});
+
+test('createPlugin default and named export', t => {
+  const output = getOutput('/fixtures/create-plugin-default-and-named');
+  const expected = readExpected('/fixtures/expected-default-and-named');
+  t.equal(output, expected);
+  t.end();
+});
+
+test('createPlugin default export multiline', t => {
+  const output = getOutput('/fixtures/create-plugin-default-multiline');
+  const expected = readExpected('/fixtures/expected-default-multiline');
+  t.equal(output, expected);
+  t.end();
+});

--- a/build/compiler.js
+++ b/build/compiler.js
@@ -229,6 +229,9 @@ function getConfig({target, env, dir, watch, cover}) {
                   require.resolve('@babel/plugin-syntax-dynamic-import'),
                   require.resolve('./babel-plugins/babel-plugin-asseturl'),
                   require.resolve(
+                    './babel-plugins/babel-plugin-pure-create-plugin'
+                  ),
+                  require.resolve(
                     './babel-plugins/babel-plugin-sync-chunk-ids'
                   ),
                   require.resolve(

--- a/build/compiler.js
+++ b/build/compiler.js
@@ -452,6 +452,7 @@ function getConfig({target, env, dir, watch, cover}) {
         }),
     ].filter(Boolean),
     optimization: {
+      sideEffects: true,
       splitChunks: target === 'web' && {
         // See https://webpack.js.org/guides/code-splitting/
         // See https://gist.github.com/sokra/1522d586b8e5c0f5072d7565c2bee693

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -303,19 +303,32 @@ test('`fusion build` tree shaking', async t => {
     'should not include nodePlugin in browser'
   );
 
-  // export default createPlugin()
+  // Default export
   t.ok(
     !fs
       .readFileSync(serverMain, 'utf-8')
       .includes('default-export-browser-plugin'),
-    'should not include browserPlugin in node'
+    'should not include default browser export in node'
   );
 
   t.ok(
     !fs
       .readFileSync(clientMain, 'utf-8')
       .includes('default-export-node-plugin'),
-    'should not include nodePlugin in browser'
+    'should not include default node export in browser'
+  );
+
+  // Named export
+  t.ok(
+    !fs
+      .readFileSync(serverMain, 'utf-8')
+      .includes('named-export-browser-plugin'),
+    'should not include named browser export in node'
+  );
+
+  t.ok(
+    !fs.readFileSync(clientMain, 'utf-8').includes('named-export-node-plugin'),
+    'should not include named node export in browser'
   );
 
   t.end();

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -268,7 +268,7 @@ test('`fusion build` with dynamic imports', async t => {
   t.end();
 });
 
-test.only('`fusion build` tree shaking', async t => {
+test('`fusion build` tree shaking', async t => {
   const dir = path.resolve(__dirname, '../fixtures/tree-shaking');
   await cmd(`build --dir=${dir} --production=true`);
 

--- a/test/fixtures/tree-shaking/src/main.js
+++ b/test/fixtures/tree-shaking/src/main.js
@@ -14,6 +14,8 @@ import defaultExportBrowserPlugin from './plugins/default-export-browser.js';
 import defaultExportNodePlugin from './plugins/default-export-node.js';
 import instrumentedAsPureBrowserPlugin from './plugins/instrumented-as-pure-browser.js';
 import instrumentedAsPureNodePlugin from './plugins/instrumented-as-pure-node.js';
+import {plugin as namedExportBrowserPlugin} from './plugins/named-export-browser.js';
+import {plugin as namedExportNodePlugin} from './plugins/named-export-node.js';
 
 export default async function() {
   const app = new App('element', el => el);
@@ -21,6 +23,8 @@ export default async function() {
   __NODE__ && app.register(defaultExportNodePlugin);
   __BROWSER__ && app.register(instrumentedAsPureBrowserPlugin);
   __NODE__ && app.register(instrumentedAsPureNodePlugin);
+  __BROWSER__ && app.register(namedExportBrowserPlugin);
+  __NODE__ && app.register(namedExportNodePlugin);
   __NODE__ &&
     app.middleware((ctx, next) => {
       if (ctx.url === '/fs') {

--- a/test/fixtures/tree-shaking/src/main.js
+++ b/test/fixtures/tree-shaking/src/main.js
@@ -10,8 +10,17 @@ import readline from 'readline';
 import repl from 'repl';
 import tls from 'tls';
 
+import defaultExportBrowserPlugin from './plugins/default-export-browser.js';
+import defaultExportNodePlugin from './plugins/default-export-node.js';
+import instrumentedAsPureBrowserPlugin from './plugins/instrumented-as-pure-browser.js';
+import instrumentedAsPureNodePlugin from './plugins/instrumented-as-pure-node.js';
+
 export default async function() {
   const app = new App('element', el => el);
+  __BROWSER__ && app.register(defaultExportBrowserPlugin);
+  __NODE__ && app.register(defaultExportNodePlugin);
+  __BROWSER__ && app.register(instrumentedAsPureBrowserPlugin);
+  __NODE__ && app.register(instrumentedAsPureNodePlugin);
   __NODE__ &&
     app.middleware((ctx, next) => {
       if (ctx.url === '/fs') {

--- a/test/fixtures/tree-shaking/src/plugins/default-export-browser.js
+++ b/test/fixtures/tree-shaking/src/plugins/default-export-browser.js
@@ -1,0 +1,7 @@
+import {createPlugin} from 'fusion-core';
+
+export default createPlugin({
+  provides() {
+    console.log('default-export-browser-plugin');
+  },
+});

--- a/test/fixtures/tree-shaking/src/plugins/default-export-node.js
+++ b/test/fixtures/tree-shaking/src/plugins/default-export-node.js
@@ -1,0 +1,7 @@
+import {createPlugin} from 'fusion-core';
+
+export default createPlugin({
+  provides() {
+    console.log('default-export-node-plugin');
+  },
+});

--- a/test/fixtures/tree-shaking/src/plugins/instrumented-as-pure-browser.js
+++ b/test/fixtures/tree-shaking/src/plugins/instrumented-as-pure-browser.js
@@ -1,0 +1,8 @@
+import {createPlugin} from 'fusion-core';
+
+const PLUGIN = /*@__PURE__*/ createPlugin({
+  provides() {
+    console.log('instrumented-as-pure-browser-plugin');
+  },
+});
+export default PLUGIN;

--- a/test/fixtures/tree-shaking/src/plugins/instrumented-as-pure-node.js
+++ b/test/fixtures/tree-shaking/src/plugins/instrumented-as-pure-node.js
@@ -1,0 +1,8 @@
+import {createPlugin} from 'fusion-core';
+
+const PLUGIN = /*@__PURE__*/ createPlugin({
+  provides() {
+    console.log('instrumented-as-pure-node-plugin');
+  },
+});
+export default PLUGIN;

--- a/test/fixtures/tree-shaking/src/plugins/named-export-browser.js
+++ b/test/fixtures/tree-shaking/src/plugins/named-export-browser.js
@@ -1,0 +1,9 @@
+import {createPlugin} from 'fusion-core';
+
+const plugin = createPlugin({
+  provides() {
+    console.log('named-export-browser-plugin');
+  },
+});
+
+export {plugin};

--- a/test/fixtures/tree-shaking/src/plugins/named-export-node.js
+++ b/test/fixtures/tree-shaking/src/plugins/named-export-node.js
@@ -1,0 +1,9 @@
+import {createPlugin} from 'fusion-core';
+
+const plugin = createPlugin({
+  provides() {
+    console.log('named-export-node-plugin');
+  },
+});
+
+export {plugin};

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ require('./route-prefix.js');
 /*
 require('./browser-support');
 */
+require('../build/babel-plugins/babel-plugin-pure-create-plugin/test');
 require('../build/babel-plugins/babel-plugin-asseturl/test');
 require('../build/babel-plugins/babel-plugin-chunkid/test');
 require('../build/babel-plugins/babel-plugin-experimentation/test');


### PR DESCRIPTION
* Cherry-pick be9b2bf73c2b1b31cd9bb07a496aba9403f1ac11 in and update tests for babel7 transpilation changes.
* Adds a tree-shaking integration test in addition to babel plugin.

Fixes #287