### PR TITLE
Fix bundle splitting in production builds

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const webpack = require('webpack');
 const ProgressBarPlugin = require('progress-bar-webpack-plugin');
-
+const WebpackChunkHash = require('webpack-chunk-hash');
 const webpackDevMiddleware = require('../lib/simple-webpack-dev-middleware');
 const ChunkManifestPlugin = require('./external-chunk-manifest-plugin.js');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
@@ -394,6 +394,8 @@ function getConfig({target, env, dir, watch, cover}) {
       env === 'production' && target === 'web'
         ? new webpack.HashedModuleIdsPlugin()
         : new webpack.NamedModulesPlugin(),
+      // Adds md5 hashing of webpack chunks
+      env === 'production' && target === 'web' && new WebpackChunkHash(),
       // This is necessary to tell webpack not to inline code referencing
       // assets. See https://github.com/webpack/webpack/issues/1315
       env === 'production' &&

--- a/build/external-chunk-manifest-plugin.js
+++ b/build/external-chunk-manifest-plugin.js
@@ -34,9 +34,7 @@ class ChunkManifestPlugin {
       );
     });
 
-    compiler.hooks.compilation.tap('ChunkManifestPlugin', function(
-      compilation
-    ) {
+    compiler.hooks.compilation.tap('ChunkManifestPlugin', compilation => {
       compilation.mainTemplate.hooks.requireEnsure.tap(
         'ChunkManifestPlugin',
         function(_, chunk, hash, chunkIdVar) {

--- a/build/external-chunk-manifest-plugin.js
+++ b/build/external-chunk-manifest-plugin.js
@@ -25,18 +25,22 @@ class ChunkManifestPlugin {
       compilation.mainTemplate.hooks.requireEnsure.tap(
         'ChunkManifestPlugin',
         function(_) {
-          oldChunkFilename = this.outputOptions.chunkFilename;
-          this.outputOptions.chunkFilename = '__CHUNK_MANIFEST__';
+          oldChunkFilename =
+            compilation.mainTemplate.outputOptions.chunkFilename;
+          compilation.mainTemplate.outputOptions.chunkFilename =
+            '__CHUNK_MANIFEST__';
           return _;
         }
       );
     });
 
-    compiler.hooks.compilation.tap('ChunkManifestPlugin', compilation => {
+    compiler.hooks.compilation.tap('ChunkManifestPlugin', function(
+      compilation
+    ) {
       compilation.mainTemplate.hooks.requireEnsure.tap(
         'ChunkManifestPlugin',
         function(_, chunk, hash, chunkIdVar) {
-          this.outputOptions.chunkFilename = oldChunkFilename;
+          compilation.mainTemplate.outputOptions.chunkFilename = oldChunkFilename;
           return _.replace(
             '"__CHUNK_MANIFEST__"',
             `window["${manifestVariable}"][${chunkIdVar}]`

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "uglifyjs-webpack-plugin": "^1.2.4",
     "unitest": "^2.1.1",
     "webpack": "^4.1.1",
+    "webpack-chunk-hash": "^0.5.0",
     "webpack-dev-middleware": "^3.0.1",
     "webpack-dev-server": "^3.1.1",
     "webpack-hot-middleware": "^2.21.2",

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -96,9 +96,26 @@ test('`fusion build` works in production with a CDN_URL', async t => {
   t.end();
 });
 
-test.only('`fusion build` works in production with dynamic imports', async () => {
-  const dir = path.resolve(__dirname, '../fixtures/dynamic-import');
+test('`fusion build` works in production in app with dynamic imports', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/dynamic-import-app');
   await cmd(`build --dir=${dir} --production`);
+
+  const clientFiles = await readdir(
+    path.resolve(dir, '.fusion/dist/production/client')
+  );
+  const clientMainFile = clientFiles.filter(f => /0-(.*?).js$/.test(f))[0];
+  const clientMain = path.resolve(
+    dir,
+    '.fusion/dist/production/client',
+    clientMainFile
+  );
+  const clientContent = fs.readFileSync(clientMain).toString();
+  t.ok(
+    clientContent.includes('loaded dynamic import'),
+    'dynamic content exists in bundle'
+  );
+
+  t.end();
 });
 
 test('`fusion build` works in production with default asset path and supplied ROUTE_PREFIX', async t => {

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -116,7 +116,7 @@ async function getDistFiles(dir) {
   };
 }
 
-test.only('`fusion build` works in production in app with dynamic imports', async t => {
+test('`fusion build` works in production in app with dynamic imports', async t => {
   const dir = path.resolve(__dirname, '../fixtures/dynamic-import-app');
   await cmd(`build --dir=${dir} --production`);
 
@@ -166,6 +166,21 @@ test.only('`fusion build` works in production in app with dynamic imports', asyn
   );
 
   // Run puppeteer test to ensure that page loads with dynamic content.
+  const {proc, port} = await start(`--dir=${dir}`);
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const page = await browser.newPage();
+  await page.goto(`http://localhost:${port}/`);
+
+  const content = await page.content();
+  t.ok(
+    content.includes('loaded-dynamic-import-updated'),
+    'app content contains loaded-dynamic-import-updated'
+  );
+
+  await browser.close();
+  proc.kill();
 
   // Clean up changed files
   fs.writeFileSync(path.resolve(dir, 'src/dynamic.js'), dynamicFileContent);

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -96,6 +96,11 @@ test('`fusion build` works in production with a CDN_URL', async t => {
   t.end();
 });
 
+test.only('`fusion build` works in production with dynamic imports', async () => {
+  const dir = path.resolve(__dirname, '../fixtures/dynamic-import');
+  await cmd(`build --dir=${dir} --production`);
+});
+
 test('`fusion build` works in production with default asset path and supplied ROUTE_PREFIX', async t => {
   const dir = path.resolve(__dirname, '../fixtures/noop');
   const serverEntryPath = path.resolve(

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -116,7 +116,7 @@ async function getDistFiles(dir) {
   };
 }
 
-test('`fusion build` works in production in app with dynamic imports', async t => {
+test('`fusion build` app with dynamic imports chunk hashing', async t => {
   const dir = path.resolve(__dirname, '../fixtures/dynamic-import-app');
   await cmd(`build --dir=${dir} --production`);
 
@@ -165,6 +165,15 @@ test('`fusion build` works in production in app with dynamic imports', async t =
     'split client file hash should change'
   );
 
+  // Clean up changed files
+  fs.writeFileSync(path.resolve(dir, 'src/dynamic.js'), dynamicFileContent);
+  t.end();
+});
+
+test('`fusion build` app with dynamic imports integration', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/dynamic-import-app');
+  await cmd(`build --dir=${dir} --production`);
+
   // Run puppeteer test to ensure that page loads with dynamic content.
   const {proc, port} = await start(`--dir=${dir}`);
   const browser = await puppeteer.launch({
@@ -175,15 +184,12 @@ test('`fusion build` works in production in app with dynamic imports', async t =
 
   const content = await page.content();
   t.ok(
-    content.includes('loaded-dynamic-import-updated'),
-    'app content contains loaded-dynamic-import-updated'
+    content.includes('loaded-dynamic-import'),
+    'app content contains loaded-dynamic-import'
   );
 
   await browser.close();
   proc.kill();
-
-  // Clean up changed files
-  fs.writeFileSync(path.resolve(dir, 'src/dynamic.js'), dynamicFileContent);
 
   t.end();
 });

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -5,6 +5,7 @@ const test = require('tape');
 const {cmd, run, start} = require('../run-command');
 const {promisify} = require('util');
 const request = require('request-promise');
+const puppeteer = require('puppeteer');
 
 const exists = promisify(fs.exists);
 const readdir = promisify(fs.readdir);
@@ -96,24 +97,78 @@ test('`fusion build` works in production with a CDN_URL', async t => {
   t.end();
 });
 
-test('`fusion build` works in production in app with dynamic imports', async t => {
-  const dir = path.resolve(__dirname, '../fixtures/dynamic-import-app');
-  await cmd(`build --dir=${dir} --production`);
-
+async function getDistFiles(dir) {
   const clientFiles = await readdir(
     path.resolve(dir, '.fusion/dist/production/client')
   );
-  const clientMainFile = clientFiles.filter(f => /0-(.*?).js$/.test(f))[0];
-  const clientMain = path.resolve(
+  const clientMainFile = clientFiles.filter(f =>
+    /client-main-(.*?).js$/.test(f)
+  )[0];
+  const clientVendorFile = clientFiles.filter(f =>
+    /client-vendor-(.*?).js$/.test(f)
+  )[0];
+  const splitClientChunks = clientFiles.filter(f => /0-(.*?).js$/.test(f));
+  return {
+    clientFiles,
+    clientMainFile,
+    clientVendorFile,
+    splitClientChunks,
+  };
+}
+
+test.only('`fusion build` works in production in app with dynamic imports', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/dynamic-import-app');
+  await cmd(`build --dir=${dir} --production`);
+
+  const distFiles = await getDistFiles(dir);
+  const dynamicFileBundlePath = path.resolve(
     dir,
     '.fusion/dist/production/client',
-    clientMainFile
+    distFiles.splitClientChunks[0]
   );
-  const clientContent = fs.readFileSync(clientMain).toString();
+
+  // Ensure that we have a dynamic chunk with content
+  const dynamicFileBundleContent = fs
+    .readFileSync(dynamicFileBundlePath)
+    .toString();
   t.ok(
-    clientContent.includes('loaded dynamic import'),
+    dynamicFileBundleContent.includes('loaded-dynamic-import'),
     'dynamic content exists in bundle'
   );
+
+  // Update dynamic file content, and rebuild.
+  const dynamicFileContent = fs
+    .readFileSync(path.resolve(dir, 'src/dynamic.js'))
+    .toString();
+  const newContent = dynamicFileContent.replace(
+    'loaded-dynamic-import',
+    'loaded-dynamic-import-updated'
+  );
+  fs.writeFileSync(path.resolve(dir, 'src/dynamic.js'), newContent);
+  await cmd(`build --dir=${dir} --production`);
+
+  // Ensure that vendor and main chunks do not change.
+  const rebuiltDistFiles = await getDistFiles(dir);
+  t.equal(
+    distFiles.clientVendorFile,
+    rebuiltDistFiles.clientVendorFile,
+    'vendor file hash should not change'
+  );
+  t.equal(
+    distFiles.clientMainFile,
+    rebuiltDistFiles.clientMainFile,
+    'main file hash should not change'
+  );
+  t.notEqual(
+    distFiles.splitClientChunks[0],
+    rebuiltDistFiles.splitClientChunks[0],
+    'split client file hash should change'
+  );
+
+  // Run puppeteer test to ensure that page loads with dynamic content.
+
+  // Clean up changed files
+  fs.writeFileSync(path.resolve(dir, 'src/dynamic.js'), dynamicFileContent);
 
   t.end();
 });

--- a/test/fixtures/dynamic-import-app/src/dynamic.js
+++ b/test/fixtures/dynamic-import-app/src/dynamic.js
@@ -1,0 +1,3 @@
+export default function() {
+  return 'loaded dynamic import';
+}

--- a/test/fixtures/dynamic-import-app/src/dynamic.js
+++ b/test/fixtures/dynamic-import-app/src/dynamic.js
@@ -1,3 +1,3 @@
 export default function() {
-  return 'loaded dynamic import';
+  return 'loaded-dynamic-import';
 }

--- a/test/fixtures/dynamic-import-app/src/main.js
+++ b/test/fixtures/dynamic-import-app/src/main.js
@@ -1,0 +1,9 @@
+// @flow
+import React from 'react';
+import App from 'fusion-react';
+import root from './root.js';
+
+export default async function start() {
+  const app = new App(root);
+  return app;
+}

--- a/test/fixtures/dynamic-import-app/src/root.js
+++ b/test/fixtures/dynamic-import-app/src/root.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import {split} from 'fusion-react-async';
+
+const LoadingComponent = () => <div />;
+const ErrorComponent = () => <div />;
+const Page = split({
+  load: () => import('./dynamic.js'),
+  LoadingComponent,
+  ErrorComponent,
+});
+
+const root = (
+  <div>
+    <Page />
+  </div>
+);
+
+export default root;

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,6 +625,25 @@
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-0.0.28.tgz#5562519bc7963caca8abf7f128cae3b594d41d06"
 
+"@types/tapable@^0":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-0.2.5.tgz#2443fc12da514c81346b1a665675559cee21fa75"
+
+"@types/uglify-js@*":
+  version "2.6.30"
+  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-2.6.30.tgz#257d2b6dd86673d60da476680fba90f2e30c6eef"
+  dependencies:
+    source-map "^0.6.1"
+
+"@types/webpack@^3.0.5":
+  version "3.8.11"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-3.8.11.tgz#df2d7f8db43dbc15b4e8ecbdc91e6f68ed6b83ab"
+  dependencies:
+    "@types/node" "*"
+    "@types/tapable" "^0"
+    "@types/uglify-js" "*"
+    source-map "^0.6.0"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -8199,6 +8218,12 @@ wbuf@^1.1.0, wbuf@^1.7.2:
 webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+
+webpack-chunk-hash@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/webpack-chunk-hash/-/webpack-chunk-hash-0.5.0.tgz#1dba38203d73c1e6ab069b6810a5a37402399dec"
+  dependencies:
+    "@types/webpack" "^3.0.5"
 
 webpack-dev-middleware@3.0.1, webpack-dev-middleware@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This fixes our production building in a way that continues to use the ChunkManifestPlugin. I'm not sure whether or not this is actually needed.

Fixes #290