### PR TITLE
Fix redirects

### DIFF
--- a/build/dev-runtime.js
+++ b/build/dev-runtime.js
@@ -161,7 +161,10 @@ module.exports.DevelopmentRuntime = function({
               hostname: 'localhost',
               port: childPort,
             });
-            const proxyReq = request(newUrl);
+            const proxyReq = request(newUrl, {
+              // let the browser follow the redirect
+              followRedirect: false,
+            });
             proxyReq.on('error', retry);
             req.pipe(proxyReq).pipe(res);
           },

--- a/test/cli/dev.js
+++ b/test/cli/dev.js
@@ -5,6 +5,8 @@ const test = require('tape');
 const {dev} = require('../run-command');
 const {promisify} = require('util');
 const request = require('request-promise');
+const requestCb = require('request');
+const Koa = require('koa');
 
 const exists = promisify(fs.exists);
 
@@ -205,4 +207,23 @@ test('`fusion dev` with named async function', async t => {
   });
   proc.kill();
   t.end();
+});
+
+test('`fusion dev` with server side redirects', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/redirect');
+  const {proc, port} = await dev(`--dir=${dir}`, {
+    stdio: 'inherit',
+  });
+  await new Promise(resolve => setTimeout(resolve, 5000));
+  requestCb(
+    {
+      uri: `http://localhost:${port}/redirect`,
+      followRedirect: false,
+    },
+    (err, res) => {
+      t.equal(res.statusCode, 302, 'responds with a 302 status code');
+      proc.kill();
+      t.end();
+    }
+  );
 });

--- a/test/fixtures/redirect/src/main.js
+++ b/test/fixtures/redirect/src/main.js
@@ -1,0 +1,15 @@
+import App from 'fusion-core';
+export default (async function() {
+  const app = new App('element', el => el);
+  if (__NODE__) {
+    app.middleware((ctx, next) => {
+      if (ctx.path === '/redirect') {
+        ctx.redirect('/test');
+      } else if (ctx.path === '/test') {
+        ctx.body = 'OK';
+      }
+      return next();
+    });
+  }
+  return app;
+});


### PR DESCRIPTION
There was an issue with redirects where the 
dev proxy followed the redirect, then proxied
the response back to the browser. This caused 
the browser url to not be updated. This PR updates
the dev proxy to not follow redirects, instead proxying
the redirect to the browser.