### PR TITLE
Ensure coverage `setup`, `spawnProc`, `finish` run and that they run in order

### DIFF
--- a/build/test-runtime.js
+++ b/build/test-runtime.js
@@ -62,9 +62,7 @@ module.exports.TestAppRuntime = function({
       // Remove existing coverage directories
       const folders = [`${rootDir}/coverage/`];
       return Promise.all(
-        folders.map(
-          folder => new Promise(resolve => rimraf(folder, () => resolve))
-        )
+        folders.map(folder => new Promise(resolve => rimraf(folder, resolve)))
       );
     };
 
@@ -107,8 +105,8 @@ module.exports.TestAppRuntime = function({
     };
 
     return setup()
-      .then(spawnProc())
-      .then(finish());
+      .then(spawnProc)
+      .then(finish);
   };
 
   this.stop = () => {


### PR DESCRIPTION
Setup wasn't actually deleting files, and `spawnProc` and `finish` were being called synchronously rather than in series. This caused the `test` command to resolve its promise early, which in turn makes it unusable programmatically (e.g. for tests)

This PR chains the async operations as intended.