### PR TITLE
Prevent crossorigin attributes for dynamically loaded scripts when same-origin

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -19,6 +19,7 @@ const resolveFrom = require('resolve-from');
 
 const AssetsManifestPlugin = require('@nadiia/file-loader')
   .assetsManifestPlugin;
+const CrossoriginAutoAttributePlugin = require('./crossorigin-auto-attribute-plugin.js');
 const ClientSourceMapPlugin = require('./client-source-map-plugin');
 const ChunkPreloadPlugin = require('./chunk-preload-plugin');
 const ChunkModuleManifestPlugin = require('./chunk-module-manifest-plugin');
@@ -458,6 +459,7 @@ function getConfig({target, env, dir, watch, cover}) {
       // case-insensitive paths can cause problems
       new CaseSensitivePathsPlugin(),
       target === 'web' && new AssetsManifestPlugin(),
+      target === 'web' && new CrossoriginAutoAttributePlugin(),
       target === 'node' &&
         new webpack.BannerPlugin({
           raw: true,

--- a/build/crossorigin-auto-attribute-plugin.js
+++ b/build/crossorigin-auto-attribute-plugin.js
@@ -1,0 +1,39 @@
+/* eslint-env node */
+
+/**
+ * There's an outstanding bug with Safari where (in violation of the spec)
+ * it doesn't send cookies for script tags with crossorigin="anonymous" attributes,
+ * even when the source url is same-origin.
+ * 
+ * See:
+ * - https://bugs.webkit.org/show_bug.cgi?id=171566
+ * - https://bugs.webkit.org/show_bug.cgi?id=171550
+ * 
+ * As a result of this, any chunks loaded by webpack will fail in Safari
+ * if they require cookies to be sent (because webpack uses crossorigin="anonymous").
+ *
+ * This plugin ensures that the crossorigin attribute is omitted
+ * unless the script src begins with `https://`.
+ *
+ * Note: if for some reason an absolute path is used even for same-origin scripts,
+ * cookies may be erronously not be sent in Safari.
+ */
+
+class CrossoriginAutoAttributePlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap('CrossoriginAutoAttributePlugin', function(
+      compilation
+    ) {
+      compilation.mainTemplate.hooks.jsonpScript.tap(
+        'JsonpMainTemplatePlugin',
+        source => {
+          return source.replace(
+            /script\.src = [^;]*;/,
+            '$& if (!script.src.match(/^https:\\/\\//)) {script.crossOrigin = void 0;}'
+          );
+        }
+      );
+    });
+  }
+}
+module.exports = CrossoriginAutoAttributePlugin;

--- a/build/crossorigin-auto-attribute-plugin.js
+++ b/build/crossorigin-auto-attribute-plugin.js
@@ -4,11 +4,11 @@
  * There's an outstanding bug with Safari where (in violation of the spec)
  * it doesn't send cookies for script tags with crossorigin="anonymous" attributes,
  * even when the source url is same-origin.
- * 
+ *
  * See:
  * - https://bugs.webkit.org/show_bug.cgi?id=171566
  * - https://bugs.webkit.org/show_bug.cgi?id=171550
- * 
+ *
  * As a result of this, any chunks loaded by webpack will fail in Safari
  * if they require cookies to be sent (because webpack uses crossorigin="anonymous").
  *

--- a/test/fixtures/dynamic-import-app/src/root.js
+++ b/test/fixtures/dynamic-import-app/src/root.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import Router, {Route, Switch} from 'fusion-plugin-react-router';
+import Router, {Route, Switch, Link} from 'fusion-plugin-react-router';
 import {split} from 'fusion-react-async';
 
 import routes from './routes';
@@ -17,6 +17,7 @@ const Page = split({
 export default function Root() {
   return (
     <div>
+      <Link id="split-route-link" to="/split-route">go to split route</Link>
       <Page />
       <Switch>
         {routes.map(({path, ...props}) => (


### PR DESCRIPTION
Fixes https://github.com/fusionjs/fusion-cli/issues/314