### PR TITLE
Fix crossorigin attribute logic for Safari

### DIFF
--- a/build/crossorigin-auto-attribute-plugin.js
+++ b/build/crossorigin-auto-attribute-plugin.js
@@ -12,11 +12,11 @@
  * As a result of this, any chunks loaded by webpack will fail in Safari
  * if they require cookies to be sent (because webpack uses crossorigin="anonymous").
  *
- * This plugin ensures that the crossorigin attribute is omitted
- * unless the script src begins with `https://`.
+ * This plugin ensures that the crossorigin attribute is omitted if the script
+ * src matches the page origin.
  *
- * Note: if for some reason an absolute path is used even for same-origin scripts,
- * cookies may be erronously not be sent in Safari.
+ * Note: `script.src` accesses the `src` property
+ * (as opposed to attribute) which yields an absolute URL per HTML5 spec
  */
 
 class CrossoriginAutoAttributePlugin {
@@ -29,7 +29,7 @@ class CrossoriginAutoAttributePlugin {
         source => {
           return source.replace(
             /script\.src = [^;]*;/,
-            '$& if (!script.src.match(/^https:\\/\\//)) {script.crossOrigin = void 0;}'
+            '$& if (!script.src.indexOf(window.location.origin)) {script.crossOrigin = void 0;}'
           );
         }
       );


### PR DESCRIPTION
Turns out `script.src` and `script.getAttribute('src')` yield different results for relative sources, which made the logic faulty. `script.src` yields an absolute URL whereas `script.getAttribute('src')` yields the relative URL.

Fixes https://github.com/fusionjs/fusion-cli/issues/314

The existing test had a false negative because tests are served via `http://` instead of `https://`. The new implementation avoids this pitfall.