### PR TITLE
Fix crash on missing node_module

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -323,7 +323,12 @@ function getConfig({target, env, dir, watch, cover}) {
             return callback();
           } else if (/^[@a-z\-0-9]+/.test(request)) {
             // do not bundle external packages and those not whitelisted
-            return callback(null, 'commonjs ' + resolveFrom(context, request));
+            const absolutePath = resolveFrom.silent(context, request);
+            if (absolutePath === null) {
+              // if module is missing, skip rewriting to absolute path
+              return callback(null, request);
+            }
+            return callback(null, 'commonjs ' + absolutePath);
           }
           // bundle everything else (local files, __*)
           return callback();


### PR DESCRIPTION
`resolve-from` throws an error by default if resolution fails. Instead, in this case, we should just leave the request as-is and let normal webpack error handling occur.

Fixes https://github.com/fusionjs/fusion-cli/issues/259