### PR TITLE
Change test metadata disk logging to be based on env var

### DIFF
--- a/build/jest/results-processor.js
+++ b/build/jest/results-processor.js
@@ -1,19 +1,12 @@
 /* eslint-env node */
 
 const fs = require('fs');
-const ci = require('ci-info');
 
 module.exports = function resultsProcessor(results) {
-  if (ci.isCI) {
-    fs.mkdir('.fusion', err => {
-      if (err && err.code !== 'EEXIST') throw err;
-      fs.writeFile(
-        './.fusion/test-results.json',
-        JSON.stringify(results, null, 2),
-        err => {
-          if (err) throw err;
-        }
-      );
+  const testMetadataPath = process.env.FUSION_TEST_METADATA_PATH;
+  if (testMetadataPath) {
+    fs.writeFile(testMetadataPath, JSON.stringify(results, null, 2), err => {
+      if (err) throw err;
     });
   }
   return results;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "browser-unhandled-rejection": "^1.0.1",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "chalk": "^2.3.2",
-    "ci-info": "^1.1.3",
     "compression-webpack-plugin": "^1.1.11",
     "core-js": "^2.5.3",
     "enzyme-adapter-react-16": "^1.1.1",

--- a/test/cli/test.js
+++ b/test/cli/test.js
@@ -272,19 +272,22 @@ test('`fusion test` environment variables', async t => {
   t.end();
 });
 
-test('`fusion test` writes results to disk in CI', async t => {
+test('`fusion test` writes results to disk based on env var', async t => {
   const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
   const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --match=passes`;
+
+  const testMetadataPath = path.join(dir, 'test-results.json');
 
   const cmd = `require('${runnerPath}').run('${args}')`;
   const response = await exec(`node -e "${cmd}"`, {
     env: Object.assign({}, process.env, {
-      CI: true,
+      FUSION_TEST_METADATA_PATH: testMetadataPath,
     }),
   });
   t.equal(countTests(response.stderr), 2, 'ran 2 tests');
-  const results = require(path.resolve(dir, '.fusion/test-results.json'));
+  const results = require(testMetadataPath);
   t.equal(results.numTotalTests, 2, 'two tests in results json');
+  fs.unlinkSync(testMetadataPath);
   t.end();
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,7 +1799,7 @@ chrome-trace-event@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-0.1.2.tgz#90f36885d5345a50621332f0717b595883d5d982"
 
-ci-info@^1.0.0, ci-info@^1.1.3:
+ci-info@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
 


### PR DESCRIPTION
This is better than the existing behavior for a couple reasons:
- Logging based on CI env was somewhat arbitrary. It may not be desired in CI, and it may be desired outside of CI. Introducing a specific env var for this is more explicit
- Distinct test runs can output to separate files if a different filename env var is set