### PR TITLE
Prevent `yarn dev` from crashing if there's a dynamic import to a non-existent dependency

### DIFF
--- a/build/instrumented-import-dependency-template.js
+++ b/build/instrumented-import-dependency-template.js
@@ -64,7 +64,7 @@ class InstrumentedImportDependencyTemplate extends ImportDependencyTemplate {
       ? // server-side, use values from client bundle
         Array.from(
           this.clientChunkMap.get(
-            dep.module.resource || dep.originModule.resource
+            (dep.module && dep.module.resource) || dep.originModule.resource
           )
         )
       : // client-side, use built-in values


### PR DESCRIPTION
Related to https://github.com/fusionjs/fusion-react-async/issues/91