### PR TITLE
Update response to include allow-timing-origin header

### DIFF
--- a/plugins/assets-plugin.js
+++ b/plugins/assets-plugin.js
@@ -18,6 +18,7 @@ module.exports = function(dir /*: string */) {
           defer: true,
           setHeaders: res => {
             res.setHeader('Cache-Control', 'public, max-age=31536000');
+            res.setHeader('Timing-Allow-Origin', '*');
           },
         })
       );


### PR DESCRIPTION
This would allow web performance endpoint to collect performance metrics for resources / assets.