### PR TITLE
Add support for checking against __NODE__ and __BROWSER__

### DIFF
--- a/build/babel-fusion-preset.js
+++ b/build/babel-fusion-preset.js
@@ -13,7 +13,6 @@ function globalsPreset(context, {target, transformGlobals}) {
       ...(transformGlobals
         ? [
             [require.resolve('babel-plugin-transform-cup-globals'), {target}],
-            // Note: plugins run first to last, cup globals must be transformed before tree shaking
             [
               require.resolve(
                 './babel-plugins/babel-plugin-transform-tree-shake'

--- a/build/babel-fusion-preset.js
+++ b/build/babel-fusion-preset.js
@@ -12,14 +12,14 @@ function globalsPreset(context, {target, transformGlobals}) {
     plugins: [
       ...(transformGlobals
         ? [
-            [
-              require.resolve('babel-plugin-transform-cup-globals'),
-              {target: target},
-            ],
+            [require.resolve('babel-plugin-transform-cup-globals'), {target}],
             // Note: plugins run first to last, cup globals must be transformed before tree shaking
-            require.resolve(
-              './babel-plugins/babel-plugin-transform-tree-shake'
-            ),
+            [
+              require.resolve(
+                './babel-plugins/babel-plugin-transform-tree-shake'
+              ),
+              {target},
+            ],
           ]
         : []),
     ],
@@ -44,3 +44,5 @@ module.exports = function buildPreset(
     ],
   };
 };
+
+module.exports.globalsPreset = globalsPreset;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-boolean-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-boolean-expression
@@ -1,4 +1,6 @@
 import { baz } from "bar";
 false;
 false;
+false;
+false;
 true && baz;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-boolean-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-boolean-expression
@@ -2,4 +2,6 @@ import foo from "foo";
 import {bar, baz} from "bar";
 false && something && other && foo;
 false && something && other && bar;
+__NODE__ && something && other && foo;
+__NODE__ && something && other && bar;
 true && baz;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/index.js
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/index.js
@@ -4,12 +4,13 @@ const fs = require('fs');
 const test = require('tape');
 const {transformFileSync} = require('@babel/core');
 const plugin = require('../');
+const {globalsPreset} = require('../../../babel-fusion-preset.js');
 
-test('boolean expression transformed', t => {
+test.only('boolean expression transformed', t => {
   const output = transformFileSync(
     __dirname + '/fixtures/input-boolean-expression',
     {
-      plugins: [plugin],
+      presets: [[globalsPreset, {target: 'browser', transformGlobals: true}]],
     }
   );
   const expected = fs

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/index.js
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/index.js
@@ -6,7 +6,7 @@ const {transformFileSync} = require('@babel/core');
 const plugin = require('../');
 const {globalsPreset} = require('../../../babel-fusion-preset.js');
 
-test.only('boolean expression transformed', t => {
+test('boolean expression transformed', t => {
   const output = transformFileSync(
     __dirname + '/fixtures/input-boolean-expression',
     {

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,3 @@
+for fixture in ./test/fixtures/*; do
+  rm -rf ./test/fixtures/$fixture/node_modules;
+done

--- a/clean.sh
+++ b/clean.sh
@@ -1,3 +1,0 @@
-for fixture in ./test/fixtures/*; do
-  rm -rf ./test/fixtures/$fixture/node_modules;
-done

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "./clean.sh && node test/index.js"
+    "test": "git clean -Xfd test/fixtures && node test/index.js"
   },
   "dependencies": {
     "@babel/core": "^7.0.0-beta.46",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "node test/index.js"
+    "test": "./clean.sh && node test/index.js"
   },
   "dependencies": {
     "@babel/core": "^7.0.0-beta.46",

--- a/test/fixtures/assets/src/main.js
+++ b/test/fixtures/assets/src/main.js
@@ -3,7 +3,7 @@ import {assetUrl} from 'fusion-core';
 
 const hoistedUrl = assetUrl('./static/test.css');
 
-export default async function() {
+export default (async function() {
   const app = new App('element', el => el);
   __NODE__ &&
     app.middleware((ctx, next) => {
@@ -18,10 +18,10 @@ export default async function() {
       } else if (ctx.url === '/hoisted') {
         ctx.body = hoistedUrl;
       }
-
-      __BROWSER__ && console.log('Dirname is', __dirname);
-      __BROWSER__ && console.log('Filename is', __filename);
       return next();
     });
+
+  __BROWSER__ && console.log('Dirname is', __dirname);
+  __BROWSER__ && console.log('Filename is', __filename);
   return app;
-}
+});


### PR DESCRIPTION
It seems that even having the cup globals plugin before the tree-shake plugin does not guarantee that the `__NODE__` and `__BROWSER__` identifiers will be replaced with literals. This adds support for checking against the `__NODE__` and `__BROWSER__` literals.