### PR TITLE
Handle else, preserve unreachable code

### DIFF
--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-boolean-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-boolean-expression
@@ -1,6 +1,6 @@
 import { baz } from "bar";
-false;
-false;
-false;
-false;
+false && something && other && foo;
+false && something && other && bar;
+false && something && other && foo;
+false && something && other && bar;
 true && baz;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-complex
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-complex
@@ -1,8 +1,19 @@
 import { universal, browserOnly } from "other";
 import browser from "browser";
-export const foo = false;
-export default browser;
-export const blah = blah ? blah : blah;
+
+if (false) {
+  if (false) {
+    node;
+    node;
+    universal;
+  }
+
+  nodeOnly;
+}
+
+export const foo = false && node && node && node;
+export default false ? node : browser;
+export const blah = false ? node : blah ? false ? node : blah : blah;
 universal;
 
 if (true) {

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-conditional-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-conditional-expression
@@ -1,2 +1,20 @@
 import { baz } from "bar";
+
+if (false) {
+  foo;
+  foo;
+}
+
+if (false) {
+  bar;
+  bar;
+}
+
 baz;
+
+if (false) {
+  foo;
+  bar;
+} else {
+  other;
+}

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-ternary
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-ternary
@@ -1,4 +1,4 @@
 import { baz } from "bar";
-other;
-other;
+false ? foo : other;
+false ? bar : other;
 true ? baz : other;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-conditional-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-conditional-expression
@@ -9,3 +9,9 @@ if (false) {
   bar;
 }
 baz;
+if (false) {
+  foo;
+  bar;
+} else {
+  other;
+}


### PR DESCRIPTION
- Fixes alternate cases w/ `IfStatement`s
- Removes pruning of unreachable code, instead only tree shake unreachable imports.