### PR TITLE
Fix coverage inclusion pattern

### DIFF
--- a/build/jest/base-jest-config.js
+++ b/build/jest/base-jest-config.js
@@ -41,7 +41,7 @@ module.exports = {
   collectCoverageFrom: [
     '**/*.js',
     '!**/__integration__/**',
-    '!**/node_modules/**'
+    '!**/node_modules/**',
   ],
   testResultsProcessor: require.resolve('./results-processor.js'),
 };

--- a/build/jest/base-jest-config.js
+++ b/build/jest/base-jest-config.js
@@ -38,6 +38,10 @@ module.exports = {
   ],
   snapshotSerializers: [require.resolve('enzyme-to-json/serializer')],
   testMatch: [`**/${testFolder}/**/*.js`],
-  collectCoverageFrom: ['**.js', '!**/__integration__/**'],
+  collectCoverageFrom: [
+    '**/*.js',
+    '!**/__integration__/**',
+    '!**/node_modules/**'
+  ],
   testResultsProcessor: require.resolve('./results-processor.js'),
 };


### PR DESCRIPTION
This broke in 5253325dd529e2cd154f950b6a84883c6a004111 because the pattern does not recursively match js files.