### PR TITLE
Add assumeNoImportSideEffects option to .fusionrc.js

### DIFF
--- a/build/babel-fusion-preset.js
+++ b/build/babel-fusion-preset.js
@@ -20,14 +20,13 @@ function globalsPreset(context /*: any */, {target, transformGlobals} /*: any */
     plugins: [
       ...(transformGlobals
         ? [
+            [require.resolve('babel-plugin-transform-cup-globals'), {target}],
             [
-              require.resolve('babel-plugin-transform-cup-globals'),
-              {target: target},
+              require.resolve(
+                './babel-plugins/babel-plugin-transform-tree-shake'
+              ),
+              {target},
             ],
-            // Note: plugins run first to last, cup globals must be transformed before tree shaking
-            require.resolve(
-              './babel-plugins/babel-plugin-transform-tree-shake'
-            ),
           ]
         : []),
     ],
@@ -52,3 +51,5 @@ module.exports = function buildPreset(
     ],
   };
 };
+
+module.exports.globalsPreset = globalsPreset;

--- a/build/babel-fusion-preset.js
+++ b/build/babel-fusion-preset.js
@@ -14,6 +14,26 @@
  * This should only be applied when compiling files in src/
  */
 
+// Needs to be a preset, because tree shaking must run after JSX plugin (in React preset)
+function globalsPreset(context /*: any */, {target, transformGlobals} /*: any */) {
+  return {
+    plugins: [
+      ...(transformGlobals
+        ? [
+            [
+              require.resolve('babel-plugin-transform-cup-globals'),
+              {target: target},
+            ],
+            // Note: plugins run first to last, cup globals must be transformed before tree shaking
+            require.resolve(
+              './babel-plugins/babel-plugin-transform-tree-shake'
+            ),
+          ]
+        : []),
+    ],
+  };
+}
+
 module.exports = function buildPreset(
   context /*: any */,
   {targets, transformGlobals = true} /*: any */
@@ -21,18 +41,14 @@ module.exports = function buildPreset(
   const target = targets.hasOwnProperty('node') ? 'node' : 'browser';
 
   return {
-    presets: [require('@babel/preset-react'), require('@babel/preset-flow')],
+    presets: [
+      require('@babel/preset-react'),
+      require('@babel/preset-flow'),
+      [globalsPreset, {target, transformGlobals}],
+    ],
     plugins: [
       require('@babel/plugin-syntax-object-rest-spread'),
       require('@babel/plugin-syntax-dynamic-import'),
-      ...(transformGlobals
-        ? [
-            [
-              require.resolve('babel-plugin-transform-cup-globals'),
-              {target: target},
-            ],
-          ]
-        : []),
     ],
   };
 };

--- a/build/babel-fusion-preset.js
+++ b/build/babel-fusion-preset.js
@@ -15,19 +15,22 @@
  */
 
 // Needs to be a preset, because tree shaking must run after JSX plugin (in React preset)
-function globalsPreset(context /*: any */, {target, transformGlobals} /*: any */) {
+function globalsPreset(
+  context /*: any */,
+  {target, transformGlobals, assumeNoImportSideEffects} /*: any */
+) {
   return {
     plugins: [
       ...(transformGlobals
         ? [
             [require.resolve('babel-plugin-transform-cup-globals'), {target}],
-            [
+            assumeNoImportSideEffects && [
               require.resolve(
                 './babel-plugins/babel-plugin-transform-tree-shake'
               ),
               {target},
             ],
-          ]
+          ].filter(Boolean)
         : []),
     ],
   };
@@ -35,7 +38,11 @@ function globalsPreset(context /*: any */, {target, transformGlobals} /*: any */
 
 module.exports = function buildPreset(
   context /*: any */,
-  {targets, transformGlobals = true} /*: any */
+  {
+    targets,
+    transformGlobals = true,
+    assumeNoImportSideEffects = false,
+  } /*: any */
 ) {
   const target = targets.hasOwnProperty('node') ? 'node' : 'browser';
 
@@ -43,7 +50,7 @@ module.exports = function buildPreset(
     presets: [
       require('@babel/preset-react'),
       require('@babel/preset-flow'),
-      [globalsPreset, {target, transformGlobals}],
+      [globalsPreset, {target, transformGlobals, assumeNoImportSideEffects}],
     ],
     plugins: [
       require('@babel/plugin-syntax-object-rest-spread'),

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/index.js
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/index.js
@@ -1,11 +1,15 @@
-/* eslint-env node */
-module.exports = (babel, {target}) => {
-  const {types: t} = babel;
+/* @flow */
 
+/* eslint-env node */
+module.exports = (
+  babel /*: any */,
+  {target} /*: {target: "node" | "browser"} */
+) => {
+  const {types: t} = babel;
   return {
     name: 'transform-tree-shake',
     visitor: {
-      ImportDeclaration(path) {
+      ImportDeclaration(path /* :any */) {
         if (path.removed) {
           return;
         }

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/index.js
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/index.js
@@ -28,8 +28,10 @@ module.exports = (
 
           const localPath = specifier.get('local');
           const localName = localPath.node.name;
+          // This should not be hardoded to React and/or improve compat with JSX transform
+          // However, this stopgap is fine until this plugin is made redundant by
+          // https://github.com/webpack/webpack/issues/7519
           if (localName === 'React') {
-            // TODO: don't hardcode identifier and/or improve compat with JSX transform
             shakeSpecifier = false;
             shakeDeclaration = false;
             break;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/index.js
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/index.js
@@ -28,7 +28,7 @@ module.exports = (
 
           const localPath = specifier.get('local');
           const localName = localPath.node.name;
-          // This should not be hardoded to React and/or improve compat with JSX transform
+          // This should not be hardcoded to React and/or improve compat with JSX transform
           // However, this stopgap is fine until this plugin is made redundant by
           // https://github.com/webpack/webpack/issues/7519
           if (localName === 'React') {

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/index.js
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/index.js
@@ -1,0 +1,98 @@
+/* eslint-env node */
+module.exports = babel => {
+  const {types: t} = babel;
+
+  return {
+    name: 'transform-tree-shake',
+    visitor: {
+      ImportDeclaration(path) {
+        if (path.removed) {
+          return;
+        }
+        let shakeTasks = [];
+        const specifiers = path.get('specifiers');
+
+        // Imports with no specifiers is probably specifically for side effects
+        let shakeDeclaration = specifiers.length > 0;
+
+        for (const specifier of specifiers) {
+          let shakeSpecifier = true;
+
+          const localPath = specifier.get('local');
+          const localName = localPath.node.name;
+          if (localName === 'React') {
+            // TODO: don't hardcode identifier and/or improve compat with JSX transform
+            shakeSpecifier = false;
+            shakeDeclaration = false;
+            break;
+          }
+          const binding = localPath.scope.bindings[localName];
+          if (binding) {
+            const refPaths = binding.referencePaths;
+            for (const path of refPaths) {
+              const task = getShakeTask(t, path);
+              if (task) {
+                shakeTasks.push(task);
+              } else {
+                shakeSpecifier = false;
+                shakeDeclaration = false;
+              }
+            }
+          } else {
+            // If binding doesn't exist, then this is an indication the import was
+            // added by a plugin (rather existing than the original source code)
+            // To be conservative, don't shake in this case.
+            shakeSpecifier = false;
+            shakeDeclaration = false;
+          }
+          if (shakeSpecifier) {
+            specifier.remove();
+          }
+        }
+
+        if (shakeDeclaration) {
+          path.remove();
+        }
+        shakeTasks.forEach(task => task());
+      },
+    },
+  };
+};
+
+function isLiteralFalse(path) {
+  const node = path.node;
+  return node.type === 'BooleanLiteral' && node.value === false;
+}
+
+function getShakeTask(t, path) {
+  while (path && !path.removed) {
+    if (path.type === 'IfStatement') {
+      if (isLiteralFalse(path.get('test'))) {
+        return () => !path.removed && path.remove();
+      }
+    } else if (path.type === 'ConditionalExpression') {
+      if (isLiteralFalse(path.get('test'))) {
+        return () => !path.removed && path.replaceWith(path.get('alternate'));
+      }
+    }
+    // traverse chained BooleanExpressions
+    // to handle cases like: `false && unknown && to_be_shaken`
+    let _path = path;
+    while (_path) {
+      if (
+        _path.type === 'LogicalExpression' &&
+        _path.get('operator').node === '&&'
+      ) {
+        _path = _path.get('left');
+        if (isLiteralFalse(_path)) {
+          return () =>
+            !path.removed && path.replaceWith(t.booleanLiteral(false));
+        }
+      } else {
+        break;
+      }
+    }
+
+    path = path.parentPath;
+  }
+}

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/index.js
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/index.js
@@ -1,5 +1,10 @@
 /* @flow */
 
+/**
+ * Note: this plugin probably becomes redundant (assuming Webpack is used) once
+ * https://github.com/webpack/webpack/issues/7519 is resolved
+ */
+
 /* eslint-env node */
 module.exports = (
   babel /*: any */,

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/index.js
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/index.js
@@ -69,8 +69,8 @@ const inverseTargetMap = {
   browser: '__NODE__',
 };
 const opposite = {
-  node: "browser",
-  browser: "node"
+  node: 'browser',
+  browser: 'node',
 };
 function isCUPGlobalFalse(path, target) {
   const node = path.node;
@@ -88,8 +88,8 @@ function isTrue(path, target) {
 function isPathCertainlyUnreachable(t, path, target) {
   while (path) {
     if (path.parentPath && path.parentPath.type === 'IfStatement') {
-      const consquent = path.parentPath.get("consequent");
-      const alternate = path.parentPath.get("alternate");
+      const consquent = path.parentPath.get('consequent');
+      const alternate = path.parentPath.get('alternate');
       if (isFalse(path.parentPath.get('test'), target) && consquent === path) {
         return true;
       }

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-boolean-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-boolean-expression
@@ -1,0 +1,4 @@
+import { baz } from "bar";
+false;
+false;
+true && baz;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-boolean-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-boolean-expression
@@ -1,6 +1,6 @@
 import { baz } from "bar";
-false;
-false;
-false;
-false;
+false && something && other && foo;
+false && something && other && bar;
+false && something && other && foo;
+false && something && other && bar;
 true && baz;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-boolean-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-boolean-expression
@@ -1,4 +1,6 @@
 import { baz } from "bar";
 false;
 false;
+false;
+false;
 true && baz;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-complex
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-complex
@@ -1,0 +1,12 @@
+import { universal, browserOnly } from "other";
+import browser from "browser";
+export const foo = false;
+export default browser;
+export const blah = blah ? blah : blah;
+universal;
+
+if (true) {
+  browser;
+  browser;
+  browserOnly;
+}

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-complex
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-complex
@@ -1,8 +1,19 @@
 import { universal, browserOnly } from "other";
 import browser from "browser";
-export const foo = false;
-export default browser;
-export const blah = blah ? blah : blah;
+
+if (false) {
+  if (false) {
+    node;
+    node;
+    universal;
+  }
+
+  nodeOnly;
+}
+
+export const foo = false && node && node && node;
+export default false ? node : browser;
+export const blah = false ? node : blah ? false ? node : blah : blah;
 universal;
 
 if (true) {

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-conditional-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-conditional-expression
@@ -1,0 +1,2 @@
+import { baz } from "bar";
+baz;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-conditional-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-conditional-expression
@@ -1,2 +1,20 @@
 import { baz } from "bar";
+
+if (false) {
+  foo;
+  foo;
+}
+
+if (false) {
+  bar;
+  bar;
+}
+
 baz;
+
+if (false) {
+  foo;
+  bar;
+} else {
+  other;
+}

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-no-specifiers
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-no-specifiers
@@ -1,0 +1,1 @@
+import "side-effect";

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-react
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-react
@@ -1,0 +1,1 @@
+import React from "react";

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-ternary
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-ternary
@@ -1,0 +1,4 @@
+import { baz } from "bar";
+other;
+other;
+true ? baz : other;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-ternary
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/expected-ternary
@@ -1,4 +1,4 @@
 import { baz } from "bar";
-other;
-other;
+false ? foo : other;
+false ? bar : other;
 true ? baz : other;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-boolean-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-boolean-expression
@@ -2,4 +2,6 @@ import foo from "foo";
 import {bar, baz} from "bar";
 false && something && other && foo;
 false && something && other && bar;
+__NODE__ && something && other && foo;
+__NODE__ && something && other && bar;
 true && baz;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-boolean-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-boolean-expression
@@ -1,0 +1,5 @@
+import foo from "foo";
+import {bar, baz} from "bar";
+false && something && other && foo;
+false && something && other && bar;
+true && baz;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-complex
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-complex
@@ -1,0 +1,20 @@
+import node from "node";
+import {universal, nodeOnly, unused, browserOnly} from "other";
+import browser from "browser";
+if (false) {
+  if(false){
+    node;
+    node;
+    universal;
+  }
+  nodeOnly;
+}
+export const foo = false && node && node && node;
+export default (false ? node : browser);
+export const blah = false ? node : blah ? false ? node : blah : blah;
+universal;
+if (true) {
+  browser;
+  browser;
+  browserOnly;
+}

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-conditional-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-conditional-expression
@@ -9,3 +9,9 @@ if (false) {
   bar;
 }
 baz;
+if (false) {
+  foo;
+  bar;
+} else {
+  other;
+}

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-conditional-expression
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-conditional-expression
@@ -1,0 +1,11 @@
+import foo from "foo";
+import {bar, baz} from "bar";
+if (false) {
+  foo;
+  foo;
+}
+if (false) {
+  bar;
+  bar;
+}
+baz;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-no-specifiers
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-no-specifiers
@@ -1,0 +1,1 @@
+import "side-effect";

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-react
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-react
@@ -1,0 +1,1 @@
+import React from "react";

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-ternary
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/fixtures/input-ternary
@@ -1,0 +1,5 @@
+import foo from "foo";
+import {bar, baz} from "bar";
+false ? foo : other;
+false ? bar : other;
+true ? baz : other;

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/index.js
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/index.js
@@ -1,0 +1,84 @@
+// @flow
+/* eslint-env node */
+const fs = require('fs');
+const test = require('tape');
+const {transformFileSync} = require('@babel/core');
+const plugin = require('../');
+
+test('boolean expression transformed', t => {
+  const output = transformFileSync(
+    __dirname + '/fixtures/input-boolean-expression',
+    {
+      plugins: [plugin],
+    }
+  );
+  const expected = fs
+    .readFileSync(__dirname + '/fixtures/expected-boolean-expression', 'utf-8')
+    .trim();
+  t.equal(output.code, expected, 'replaced correctly');
+  t.end();
+});
+
+test('conditional expression transformed', t => {
+  const output = transformFileSync(
+    __dirname + '/fixtures/input-conditional-expression',
+    {
+      plugins: [plugin],
+    }
+  );
+  const expected = fs
+    .readFileSync(
+      __dirname + '/fixtures/expected-conditional-expression',
+      'utf-8'
+    )
+    .trim();
+  t.equal(output.code, expected, 'replaced correctly');
+  t.end();
+});
+
+test('import with no specifiers', t => {
+  const output = transformFileSync(
+    __dirname + '/fixtures/input-no-specifiers',
+    {
+      plugins: [plugin],
+    }
+  );
+  const expected = fs
+    .readFileSync(__dirname + '/fixtures/expected-no-specifiers', 'utf-8')
+    .trim();
+  t.equal(output.code, expected, 'replaced correctly');
+  t.end();
+});
+
+test('import react', t => {
+  const output = transformFileSync(__dirname + '/fixtures/input-react', {
+    plugins: [plugin],
+  });
+  const expected = fs
+    .readFileSync(__dirname + '/fixtures/expected-react', 'utf-8')
+    .trim();
+  t.equal(output.code, expected, 'replaced correctly');
+  t.end();
+});
+
+test('transforms ternary', t => {
+  const output = transformFileSync(__dirname + '/fixtures/input-ternary', {
+    plugins: [plugin],
+  });
+  const expected = fs
+    .readFileSync(__dirname + '/fixtures/expected-ternary', 'utf-8')
+    .trim();
+  t.equal(output.code, expected, 'replaced correctly');
+  t.end();
+});
+
+test('transforms complex', t => {
+  const output = transformFileSync(__dirname + '/fixtures/input-complex', {
+    plugins: [plugin],
+  });
+  const expected = fs
+    .readFileSync(__dirname + '/fixtures/expected-complex', 'utf-8')
+    .trim();
+  t.equal(output.code, expected, 'replaced correctly');
+  t.end();
+});

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/index.js
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/index.js
@@ -10,7 +10,16 @@ test('boolean expression transformed', t => {
   const output = transformFileSync(
     __dirname + '/fixtures/input-boolean-expression',
     {
-      presets: [[globalsPreset, {target: 'browser', transformGlobals: true}]],
+      presets: [
+        [
+          globalsPreset,
+          {
+            target: 'browser',
+            transformGlobals: true,
+            assumeNoImportSideEffects: true,
+          },
+        ],
+      ],
     }
   );
   const expected = fs

--- a/build/babel-plugins/babel-plugin-transform-tree-shake/test/index.js
+++ b/build/babel-plugins/babel-plugin-transform-tree-shake/test/index.js
@@ -4,12 +4,13 @@ const fs = require('fs');
 const test = require('tape');
 const {transformFileSync} = require('@babel/core');
 const plugin = require('../');
+const {globalsPreset} = require('../../../babel-fusion-preset.js');
 
 test('boolean expression transformed', t => {
   const output = transformFileSync(
     __dirname + '/fixtures/input-boolean-expression',
     {
-      plugins: [plugin],
+      presets: [[globalsPreset, {target: 'browser', transformGlobals: true}]],
     }
   );
   const expected = fs

--- a/build/compiler.js
+++ b/build/compiler.js
@@ -308,6 +308,8 @@ function getConfig({target, env, dir, watch, cover}) {
                         require.resolve('./babel-fusion-preset.js'),
                         {
                           targets,
+                          assumeNoImportSideEffects:
+                            fusionConfig.assumeNoImportSideEffects,
                         },
                       ],
                     ],
@@ -319,7 +321,11 @@ function getConfig({target, env, dir, watch, cover}) {
             },
           ],
         },
-      ],
+        fusionConfig.assumeNoImportSideEffects && {
+          sideEffects: false,
+          test: () => true,
+        },
+      ].filter(Boolean),
     },
     externals: [
       // These externals are required to work with enzyme

--- a/build/load-fusionrc.js
+++ b/build/load-fusionrc.js
@@ -17,7 +17,7 @@ let loggedNotice = false;
 
 module.exports = function validateConfig(
   dir /*: any */
-) /*: {babel?: {include?: Array<any>, exclude?: Array<any>}, assumeNoImportSideEffects?: boolean} */ {
+) /*: {babel?: {plugins?: Array<any>, presets?: Array<any>}, assumeNoImportSideEffects?: boolean} */ {
   const configPath = path.join(dir, '.fusionrc.js');
   let config;
   if (fs.existsSync(configPath)) {

--- a/build/load-fusionrc.js
+++ b/build/load-fusionrc.js
@@ -15,7 +15,9 @@ const chalk = require('chalk');
 
 let loggedNotice = false;
 
-module.exports = function validateConfig(dir /*: any */) {
+module.exports = function validateConfig(
+  dir /*: any */
+) /*: {babel?: {include?: Array<any>, exclude?: Array<any>}, assumeNoImportSideEffects?: boolean} */ {
   const configPath = path.join(dir, '.fusionrc.js');
   let config;
   if (fs.existsSync(configPath)) {

--- a/build/load-fusionrc.js
+++ b/build/load-fusionrc.js
@@ -42,11 +42,38 @@ module.exports = function validateConfig(dir /*: any */) {
 };
 
 function isValid(config) {
-  return (
-    typeof config === 'object' &&
-    config !== null &&
-    Object.keys(config).every(el => ['babel'].includes(el)) &&
+  if (!(typeof config === 'object' && config !== null)) {
+    throw new Error('.fusionrc.js must export an object');
+  }
+
+  if (
+    !Object.keys(config).every(key =>
+      ['babel', 'assumeNoImportSideEffects'].includes(key)
+    )
+  ) {
+    throw new Error(`Invalid property in .fusionrc.js`);
+  }
+
+  if (
     config.babel &&
-    Object.keys(config.babel).every(el => ['plugins', 'presets'].includes(el))
-  );
+    !Object.keys(config.babel).every(el => ['plugins', 'presets'].includes(el))
+  ) {
+    throw new Error(
+      `Only "plugins" and "presets" are supported in fusionrc.js babel config`
+    );
+  }
+
+  if (
+    !(
+      config.assumeNoImportSideEffects === false ||
+      config.assumeNoImportSideEffects === true ||
+      config.assumeNoImportSideEffects === void 0
+    )
+  ) {
+    throw new Error(
+      'assumeNoImportSideEffects must be true, false, or undefined in fusionrc.js babel config'
+    );
+  }
+
+  return true;
 }

--- a/docs/babel-config.md
+++ b/docs/babel-config.md
@@ -1,15 +1,3 @@
 # Custom Babel Configuration
 
-## Adding plugins/presets
-
-To add your own Babel plugins/prelease, create a `.fusionrc.js` in the root directory of your application with the following contents:
-```
-module.exports = {
-  babel: {
-    presets: ["some-babel-preset"],
-    plugins: ["some-babel-plugin"]
-  }
-};
-```
-
-**Please note that custom Babel config is an unstable API and may not be supported in future releases.**
+See [fusionrc.md](fusionrc.md#babel)

--- a/docs/fusionrc.md
+++ b/docs/fusionrc.md
@@ -8,7 +8,8 @@ This configuration object supports the following fields:
 
 ### Adding plugins/presets
 
-To add your own Babel plugins/prelease, create a 
+For example, to add your own Babel plugins/preset:
+
 ```
 module.exports = {
   babel: {

--- a/docs/fusionrc.md
+++ b/docs/fusionrc.md
@@ -29,3 +29,10 @@ By default this is `false`.
 Setting this to `true` enables the assumption that modules in your code do not have any import side effects. This assumption allows for more powerful tree shaking and pruning of unused imports.
 
 This option may be useful if you import modules that use Node.js built-ins. This option makes it easier to avoid uninintionally including server-specific code in the browser bundle.
+
+For specifics regarding implementation details, see:
+ - https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
+ - https://github.com/webpack/webpack/tree/master/examples/side-effects
+ - https://stackoverflow.com/questions/49160752/what-does-webpack-4-expect-from-a-package-with-sideeffects-false/49203452#49203452
+
+In the future, it is possible that some form of this behavior may be turned on by default (with ways to opt-out instead).

--- a/docs/fusionrc.md
+++ b/docs/fusionrc.md
@@ -1,0 +1,30 @@
+# `.fusionrc.js`
+
+Fusion supports a `.fusionrc.js` in the root directory of your application. This must be a CommonJS module exporting an object.
+
+This configuration object supports the following fields:
+
+## `babel`
+
+### Adding plugins/presets
+
+To add your own Babel plugins/prelease, create a 
+```
+module.exports = {
+  babel: {
+    presets: ["some-babel-preset"],
+    plugins: ["some-babel-plugin"]
+  }
+};
+```
+
+**Please note that custom Babel config is an unstable API and may not be supported in future releases.**
+
+
+## `assumeNoImportSideEffects`
+
+By default this is `false`.
+
+Setting this to `true` enables the assumption that modules in your code do not have any import side effects. This assumption allows for more powerful tree shaking and pruning of unused imports.
+
+This option may be useful if you import modules that use Node.js built-ins. This option makes it easier to avoid uninintionally including server-specific code in the browser bundle.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "node test/index.js"
+    "test": "git clean -Xfd test/fixtures && node test/index.js"
   },
   "dependencies": {
     "@babel/core": "^7.0.0-beta.49",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "chalk": "^2.4.1",
     "compression-webpack-plugin": "^1.1.11",
-    "core-js": "^2.5.6",
+    "core-js": "^2.5.7",
     "enzyme-adapter-react-15": "^1.0.5",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.4",
@@ -101,7 +101,7 @@
   },
   "peerDependencies": {
     "enzyme": "^3.3.0",
-    "fusion-core": "^1.2.6",
+    "fusion-core": "^1.3.1",
     "fusion-tokens": "^1.0.3"
   },
   "engines": {

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -165,7 +165,7 @@ test('`fusion build` app with dynamic imports chunk hashing', async t => {
     rebuiltDistFiles.clientVendorFile,
     'vendor file hash should not change'
   );
-  // TODO(#385) Add this back https://github.com/fusionjs/fusion-cli/pull/385
+  // TODO(#393) Add this back https://github.com/fusionjs/fusion-cli/pull/385
   // t.equal(
   //   distFiles.clientMainFile,
   //   rebuiltDistFiles.clientMainFile,

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -421,25 +421,6 @@ test('`fusion build` with dynamic imports and group chunks', async t => {
   t.end();
 });
 
-test('`fusion build` with dynamic imports and group chunks', async t => {
-  const dir = path.resolve(__dirname, '../fixtures/import-pruning');
-  await cmd(`build --dir=${dir}`);
-  const {proc, port} = await start(`--dir=${dir}`, {
-    env: {
-      ...process.env,
-      NODE_ENV: 'production',
-    },
-  });
-  const resA = await request(`http://localhost:${port}/test-a`);
-  const resB = await request(`http://localhost:${port}/test-b`);
-  const res = await request(`http://localhost:${port}/test`);
-  t.deepLooseEqual(JSON.parse(res), [0]);
-  t.deepLooseEqual(JSON.parse(resA), [0, 2]);
-  t.deepLooseEqual(JSON.parse(resB), [0, 1]);
-  proc.kill();
-  t.end();
-});
-
 test('`fusion build` tree shaking unused imports in dev w/ assumeNoImportSideEffects: true', async t => {
   const dir = path.resolve(__dirname, '../fixtures/tree-shaking-unused');
   await cmd(`build --dir=${dir}`);

--- a/test/fixtures/assets/src/main.js
+++ b/test/fixtures/assets/src/main.js
@@ -3,7 +3,7 @@ import {assetUrl} from 'fusion-core';
 
 const hoistedUrl = assetUrl('./static/test.css');
 
-export default async function() {
+export default (async function() {
   const app = new App('element', el => el);
   __NODE__ &&
     app.middleware((ctx, next) => {
@@ -18,10 +18,10 @@ export default async function() {
       } else if (ctx.url === '/hoisted') {
         ctx.body = hoistedUrl;
       }
-
-      __BROWSER__ && console.log('Dirname is', __dirname);
-      __BROWSER__ && console.log('Filename is', __filename);
       return next();
     });
+
+  __BROWSER__ && console.log('Dirname is', __dirname);
+  __BROWSER__ && console.log('Filename is', __filename);
   return app;
-}
+});

--- a/test/fixtures/missing-module/src/main.js
+++ b/test/fixtures/missing-module/src/main.js
@@ -1,4 +1,4 @@
 // importing a non-existent module should generate a compiler error
-import {foo} from '__non_existent_module__';
+import '__non_existent_module__';
 
 export default function() {}

--- a/test/fixtures/test-jest-app/__tests__/__snapshots__/snapshot-enzyme-no-match.js.snap
+++ b/test/fixtures/test-jest-app/__tests__/__snapshots__/snapshot-enzyme-no-match.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Enzyme wrapper snapshotting 1`] = `<div />`;

--- a/test/fixtures/test-jest-app/__tests__/__snapshots__/snapshot-enzyme-no-match.js.snap
+++ b/test/fixtures/test-jest-app/__tests__/__snapshots__/snapshot-enzyme-no-match.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Enzyme wrapper snapshotting 1`] = `<div />`;

--- a/test/fixtures/tree-shaking-unused/.fusionrc.js
+++ b/test/fixtures/tree-shaking-unused/.fusionrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  assumeNoImportSideEffects: true
+};

--- a/test/fixtures/tree-shaking-unused/.gitignore
+++ b/test/fixtures/tree-shaking-unused/.gitignore
@@ -1,0 +1,2 @@
+!node_modules
+.fusion_babel_cache/

--- a/test/fixtures/tree-shaking-unused/node_modules/fixture-pkg/index.js
+++ b/test/fixtures/tree-shaking-unused/node_modules/fixture-pkg/index.js
@@ -1,0 +1,2 @@
+export * from "./used.js";
+export * from "./unused.js";

--- a/test/fixtures/tree-shaking-unused/node_modules/fixture-pkg/package.json
+++ b/test/fixtures/tree-shaking-unused/node_modules/fixture-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-es2017-pkg",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/fixtures/tree-shaking-unused/node_modules/fixture-pkg/unused.js
+++ b/test/fixtures/tree-shaking-unused/node_modules/fixture-pkg/unused.js
@@ -1,0 +1,1 @@
+export const unused = "__fixture_pkg_unused__";

--- a/test/fixtures/tree-shaking-unused/node_modules/fixture-pkg/used.js
+++ b/test/fixtures/tree-shaking-unused/node_modules/fixture-pkg/used.js
@@ -1,0 +1,1 @@
+export const used = "__fixture_pkg_used__";

--- a/test/fixtures/tree-shaking-unused/src/main.js
+++ b/test/fixtures/tree-shaking-unused/src/main.js
@@ -6,6 +6,12 @@ if (__NODE__) {
   console.log(unused, unused2);
 }
 
+// unused in the browser
+// Note: the tree shaking babel plugin is needed to handle this case until
+// https://github.com/webpack/webpack/issues/7519 is resolved
+__NODE__ && unused;
+__NODE__ && unused2;
+
 console.log(used, used2);
 
 export default () => {}

--- a/test/fixtures/tree-shaking-unused/src/main.js
+++ b/test/fixtures/tree-shaking-unused/src/main.js
@@ -1,0 +1,11 @@
+import {used, unused} from "fixture-pkg";
+import {used2, unused2} from "./user-code.js";
+
+if (__NODE__) {
+  // unused in the browser
+  console.log(unused, unused2);
+}
+
+console.log(used, used2);
+
+export default () => {}

--- a/test/fixtures/tree-shaking-unused/src/unused2.js
+++ b/test/fixtures/tree-shaking-unused/src/unused2.js
@@ -1,0 +1,1 @@
+export const unused2 = "__fixture_pkg_unused__";

--- a/test/fixtures/tree-shaking-unused/src/used2.js
+++ b/test/fixtures/tree-shaking-unused/src/used2.js
@@ -1,0 +1,1 @@
+export const used2 = "__fixture_pkg_used__";

--- a/test/fixtures/tree-shaking-unused/src/user-code.js
+++ b/test/fixtures/tree-shaking-unused/src/user-code.js
@@ -1,0 +1,2 @@
+export * from "./used2.js";
+export * from "./unused2.js";

--- a/test/index.js
+++ b/test/index.js
@@ -28,3 +28,4 @@ require('../build/babel-plugins/babel-plugin-sw/test');
 require('../build/babel-plugins/babel-plugin-sync-chunk-ids/test');
 require('../build/babel-plugins/babel-plugin-sync-chunk-paths/test');
 require('../build/babel-plugins/babel-plugin-utils/test');
+require('../build/babel-plugins/babel-plugin-transform-tree-shake/test');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,9 +2025,9 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
-core-js@^2.5.6:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
+core-js@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,7 +73,6 @@
     "@babel/helper-explode-assignable-expression" "7.0.0-beta.49"
     "@babel/types" "7.0.0-beta.49"
 
-<<<<<<< HEAD
 "@babel/helper-builder-react-jsx@7.0.0-beta.48":
   version "7.0.0-beta.48"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.48.tgz#bdfd701514382c495a879f11d4aab835e86a7740"
@@ -100,27 +99,6 @@
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.49.tgz#4ea067aa720937240df395cd073c24fcad9c2b3b"
   dependencies:
-=======
-"@babel/helper-builder-react-jsx@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.49.tgz#e6c35f8c88e90093139fa7b3027d05cceb47f43d"
-  dependencies:
-    "@babel/types" "7.0.0-beta.49"
-    esutils "^2.0.0"
-
-"@babel/helper-call-delegate@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.49.tgz#4b5d41782a683d5dc6497834a32310a8d02a3af9"
-  dependencies:
-    "@babel/helper-hoist-variables" "7.0.0-beta.49"
-    "@babel/traverse" "7.0.0-beta.49"
-    "@babel/types" "7.0.0-beta.49"
-
-"@babel/helper-define-map@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.49.tgz#4ea067aa720937240df395cd073c24fcad9c2b3b"
-  dependencies:
->>>>>>> Upgrade dependencies
     "@babel/helper-function-name" "7.0.0-beta.49"
     "@babel/types" "7.0.0-beta.49"
     lodash "^4.17.5"
@@ -195,13 +173,10 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.49.tgz#a98b43c3a6c54bef48f87b10dc4568dec0b41bf7"
   dependencies:
     "@babel/types" "7.0.0-beta.49"
-<<<<<<< HEAD
 
 "@babel/helper-plugin-utils@7.0.0-beta.48":
   version "7.0.0-beta.48"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.48.tgz#bf310f89e91d146ac0f1369562164be45edba587"
-=======
->>>>>>> Upgrade dependencies
 
 "@babel/helper-plugin-utils@7.0.0-beta.49":
   version "7.0.0-beta.49"
@@ -297,7 +272,6 @@
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.49.tgz#944d0c5ba2812bb159edbd226743afd265179bdc"
 
-<<<<<<< HEAD
 "@babel/plugin-proposal-async-generator-functions@7.0.0-beta.49":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.49.tgz#8761a5e2d8b5251e70df28f4d0aa64aa28a596b1"
@@ -368,78 +342,6 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.48.tgz#c8bf06aa238009fd0ae01d5d490b7b455a5e6295"
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.48"
-=======
-"@babel/plugin-external-helpers@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0-beta.49.tgz#c67ffa9e23d7063810b0d4304857bf5c16f8a35b"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-proposal-async-generator-functions@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.49.tgz#8761a5e2d8b5251e70df28f4d0aa64aa28a596b1"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-    "@babel/helper-remap-async-to-generator" "7.0.0-beta.49"
-    "@babel/plugin-syntax-async-generators" "7.0.0-beta.49"
-
-"@babel/plugin-proposal-class-properties@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.49.tgz#527e90af75d23fd5e3bae1a218dc0a6d9236b5f1"
-  dependencies:
-    "@babel/helper-function-name" "7.0.0-beta.49"
-    "@babel/helper-member-expression-to-functions" "7.0.0-beta.49"
-    "@babel/helper-optimise-call-expression" "7.0.0-beta.49"
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-    "@babel/helper-replace-supers" "7.0.0-beta.49"
-    "@babel/plugin-syntax-class-properties" "7.0.0-beta.49"
-
-"@babel/plugin-proposal-object-rest-spread@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.49.tgz#6d0cd60f7a7bd7c444a371c4e9470bff02f5777c"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.49"
-
-"@babel/plugin-proposal-optional-catch-binding@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.49.tgz#1f53d36785101d5eb4b55d65686aa2b39fa21c4b"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-    "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.49"
-
-"@babel/plugin-proposal-unicode-property-regex@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.49.tgz#0ef5fb9abda980cd1585ef4c8e8f680b63263c72"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-    "@babel/helper-regex" "7.0.0-beta.49"
-    regexpu-core "^4.1.4"
-
-"@babel/plugin-syntax-async-generators@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.49.tgz#50ee943002aedc9ab3a8d12292bd35dd9edb1df8"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-syntax-class-properties@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.49.tgz#6a14fa47ceaa32b53e14e6648326e52dab306904"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-syntax-dynamic-import@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.49.tgz#f0af7ac6b53676a496093d4a6e2a2ec655c07b78"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-syntax-flow@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0-beta.49.tgz#5b3f0b65ca9660534535643b82530fb1d58e63ee"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
->>>>>>> Upgrade dependencies
 
 "@babel/plugin-syntax-jsx@7.0.0-beta.49":
   version "7.0.0-beta.49"
@@ -447,11 +349,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
 
-<<<<<<< HEAD
 "@babel/plugin-syntax-object-rest-spread@7.0.0-beta.49":
-=======
-"@babel/plugin-syntax-object-rest-spread@7.0.0-beta.49", "@babel/plugin-syntax-object-rest-spread@^7.0.0-beta.49":
->>>>>>> Upgrade dependencies
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.49.tgz#4784b3880823ff12e742c26b41e9857f701d639e"
   dependencies:
@@ -526,7 +424,6 @@
 "@babel/plugin-transform-duplicate-keys@7.0.0-beta.49":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.49.tgz#fac244809ddecbf095e375558ccb716da1042316"
-<<<<<<< HEAD
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
 
@@ -618,93 +515,6 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.48.tgz#a4adc3bf255ffccc0beac8b9dd9c283a53bf8956"
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.48"
-=======
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-transform-exponentiation-operator@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.49.tgz#457b2d09004794684aa6e1b04015080b80a08a14"
-  dependencies:
-    "@babel/helper-builder-binary-assignment-operator-visitor" "7.0.0-beta.49"
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-transform-flow-strip-types@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0-beta.49.tgz#f02a26528e94b2c1d11d9573b63ee5782d4f2af9"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-    "@babel/plugin-syntax-flow" "7.0.0-beta.49"
-
-"@babel/plugin-transform-for-of@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.49.tgz#3ec72726bf1d89a0d4d511be7a9549066f57aade"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-transform-function-name@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.49.tgz#af39f60e7aefce9b25eb4adcedd04d50866ce218"
-  dependencies:
-    "@babel/helper-function-name" "7.0.0-beta.49"
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-transform-literals@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.49.tgz#07c838254d65e6867e86513eb0f22d5f26b0a56a"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-transform-modules-amd@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.49.tgz#16d07480954b0415ea70f1ec3edbd0597bd3ddfe"
-  dependencies:
-    "@babel/helper-module-transforms" "7.0.0-beta.49"
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-transform-modules-commonjs@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.49.tgz#09fb345d5927c2ba3bd89e7cdb13a55067ed39a0"
-  dependencies:
-    "@babel/helper-module-transforms" "7.0.0-beta.49"
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-    "@babel/helper-simple-access" "7.0.0-beta.49"
-
-"@babel/plugin-transform-modules-systemjs@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.49.tgz#68225a3ae1312771bc5a36f71ff10d02c1243d9f"
-  dependencies:
-    "@babel/helper-hoist-variables" "7.0.0-beta.49"
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-transform-modules-umd@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.49.tgz#7048ca5a77189706f4b3e96e4b996eb30590dd63"
-  dependencies:
-    "@babel/helper-module-transforms" "7.0.0-beta.49"
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-transform-new-target@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.49.tgz#c2ffef1ebbaf724a9e58dde114e57e3e6864a5e7"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-
-"@babel/plugin-transform-object-super@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.49.tgz#b302f55702847343c10ff4fb8435cc3574755fe3"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-    "@babel/helper-replace-supers" "7.0.0-beta.49"
-
-"@babel/plugin-transform-parameters@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.49.tgz#1cad71a2a33281e5efbb1a4623a964c073ce9a2d"
-  dependencies:
-    "@babel/helper-call-delegate" "7.0.0-beta.49"
-    "@babel/helper-get-function-arity" "7.0.0-beta.49"
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
->>>>>>> Upgrade dependencies
 
 "@babel/plugin-transform-react-display-name@7.0.0-beta.49":
   version "7.0.0-beta.49"
@@ -712,7 +522,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
 
-<<<<<<< HEAD
 "@babel/plugin-transform-react-jsx-self@7.0.0-beta.48":
   version "7.0.0-beta.48"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.48.tgz#fb0e87a38af96706ff642c64fa2e68be126aaf4f"
@@ -723,23 +532,10 @@
 "@babel/plugin-transform-react-jsx-self@7.0.0-beta.49":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.49.tgz#a11828ba38035c1aa93fd44099b9897019fa546c"
-=======
-"@babel/plugin-transform-react-jsx-self@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.49.tgz#a11828ba38035c1aa93fd44099b9897019fa546c"
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
     "@babel/plugin-syntax-jsx" "7.0.0-beta.49"
 
-"@babel/plugin-transform-react-jsx-source@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.49.tgz#05bb7429b6dd44cbdca69585481347a809caa8ca"
->>>>>>> Upgrade dependencies
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-    "@babel/plugin-syntax-jsx" "7.0.0-beta.49"
-
-<<<<<<< HEAD
 "@babel/plugin-transform-react-jsx-source@7.0.0-beta.48":
   version "7.0.0-beta.48"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.48.tgz#8af9a9c9ae6b8515dcaa84d8f50a88e176ea5138"
@@ -770,16 +566,6 @@
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
     "@babel/plugin-syntax-jsx" "7.0.0-beta.49"
 
-=======
-"@babel/plugin-transform-react-jsx@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.49.tgz#0f2789fde305c3c14151848f8514a2af1441af58"
-  dependencies:
-    "@babel/helper-builder-react-jsx" "7.0.0-beta.49"
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-    "@babel/plugin-syntax-jsx" "7.0.0-beta.49"
-
->>>>>>> Upgrade dependencies
 "@babel/plugin-transform-regenerator@7.0.0-beta.49":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.49.tgz#d4ed7967033f4f5b49363c203503899b8357cae2"
@@ -873,7 +659,6 @@
 "@babel/preset-flow@7.0.0-beta.49":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.0.0-beta.49.tgz#10cbee1a60db207120a4443c54c0ca5f734eb390"
-<<<<<<< HEAD
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
     "@babel/plugin-transform-flow-strip-types" "7.0.0-beta.49"
@@ -897,21 +682,6 @@
     "@babel/plugin-transform-react-jsx" "7.0.0-beta.48"
     "@babel/plugin-transform-react-jsx-self" "7.0.0-beta.48"
     "@babel/plugin-transform-react-jsx-source" "7.0.0-beta.48"
-=======
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-    "@babel/plugin-transform-flow-strip-types" "7.0.0-beta.49"
-
-"@babel/preset-react@7.0.0-beta.49", "@babel/preset-react@^7.0.0-beta.47":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.0.0-beta.49.tgz#0c86770f6e78a49af6f86942f5980beb5feb76c5"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.49"
-    "@babel/plugin-transform-react-display-name" "7.0.0-beta.49"
-    "@babel/plugin-transform-react-jsx" "7.0.0-beta.49"
-    "@babel/plugin-transform-react-jsx-self" "7.0.0-beta.49"
-    "@babel/plugin-transform-react-jsx-source" "7.0.0-beta.49"
->>>>>>> Upgrade dependencies
 
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -969,7 +739,6 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-<<<<<<< HEAD
 "@babel/types@7.0.0-beta.48":
   version "7.0.0-beta.48"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.48.tgz#095872fa6f8a87846f5872a39a938f34d5dc55a3"
@@ -984,14 +753,6 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.5"
-=======
-"@babel/types@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.49.tgz#b7e3b1c3f4d4cfe11bdf8c89f1efd5e1617b87a6"
-  dependencies:
-    esutils "^2.0.2"
-    lodash "^4.17.5"
->>>>>>> Upgrade dependencies
     to-fast-properties "^2.0.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
@@ -1028,7 +789,6 @@
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.4.3.tgz#f5aee4c376a717c74264d7bacada981e7e44faad"
 
-<<<<<<< HEAD
 "@webassemblyjs/helper-buffer@1.4.3":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.4.3.tgz#0434b55958519bf503697d3824857b1dea80b729"
@@ -1130,133 +890,6 @@
   dependencies:
     "@webassemblyjs/ast" "1.4.3"
     "@webassemblyjs/wast-parser" "1.4.3"
-=======
-"@webassemblyjs/ast@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.5.8.tgz#f75ac7e7602b7833abd5d53951baae8a07ebb5df"
-  dependencies:
-    "@webassemblyjs/helper-module-context" "1.5.8"
-    "@webassemblyjs/helper-wasm-bytecode" "1.5.8"
-    "@webassemblyjs/wast-parser" "1.5.8"
-    debug "^3.1.0"
-    mamacro "^0.0.3"
-
-"@webassemblyjs/floating-point-hex-parser@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.5.8.tgz#e0604d34fab0c910e16113720a5a3c01f558fa54"
-
-"@webassemblyjs/helper-api-error@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.5.8.tgz#f5570aff60090fae1b78a690a95d04cb021da9ca"
-
-"@webassemblyjs/helper-buffer@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.5.8.tgz#b1405e819a2c537964682fb70551796ab9602632"
-  dependencies:
-    debug "^3.1.0"
-
-"@webassemblyjs/helper-code-frame@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.5.8.tgz#6439de475720198a48fa8b4c38e41987798f73cc"
-  dependencies:
-    "@webassemblyjs/wast-printer" "1.5.8"
-
-"@webassemblyjs/helper-fsm@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.5.8.tgz#6169af3c9530cf9e89a8f3cf2970ed70e650ae4f"
-
-"@webassemblyjs/helper-module-context@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.5.8.tgz#73d0de45cebb774d465b5a66fef061f834d6c23c"
-
-"@webassemblyjs/helper-wasm-bytecode@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.5.8.tgz#60df17f72d12b07e1398756e6ebfe59c03ab2e1a"
-
-"@webassemblyjs/helper-wasm-section@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.5.8.tgz#cda7fdb6f3b7b0d215c8f92b7435d47726822f49"
-  dependencies:
-    "@webassemblyjs/ast" "1.5.8"
-    "@webassemblyjs/helper-buffer" "1.5.8"
-    "@webassemblyjs/helper-wasm-bytecode" "1.5.8"
-    "@webassemblyjs/wasm-gen" "1.5.8"
-    debug "^3.1.0"
-
-"@webassemblyjs/ieee754@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.5.8.tgz#29383c7172e90121613d5614d532f22c19255c3b"
-  dependencies:
-    ieee754 "^1.1.11"
-
-"@webassemblyjs/leb128@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.5.8.tgz#657c48ef2537ea2921e897a50157be700bf24eac"
-  dependencies:
-    leb "^0.3.0"
-
-"@webassemblyjs/wasm-edit@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.5.8.tgz#592d3678894eaa2ee7e7c2c6a13c2a697db1aa7e"
-  dependencies:
-    "@webassemblyjs/ast" "1.5.8"
-    "@webassemblyjs/helper-buffer" "1.5.8"
-    "@webassemblyjs/helper-wasm-bytecode" "1.5.8"
-    "@webassemblyjs/helper-wasm-section" "1.5.8"
-    "@webassemblyjs/wasm-gen" "1.5.8"
-    "@webassemblyjs/wasm-opt" "1.5.8"
-    "@webassemblyjs/wasm-parser" "1.5.8"
-    "@webassemblyjs/wast-printer" "1.5.8"
-    debug "^3.1.0"
-
-"@webassemblyjs/wasm-gen@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.5.8.tgz#e94e034a45227aaa7c481b25c1aa9a0a00ab9488"
-  dependencies:
-    "@webassemblyjs/ast" "1.5.8"
-    "@webassemblyjs/helper-wasm-bytecode" "1.5.8"
-    "@webassemblyjs/ieee754" "1.5.8"
-    "@webassemblyjs/leb128" "1.5.8"
-
-"@webassemblyjs/wasm-opt@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.5.8.tgz#a3a0d00d98dee0f3cf2ae41084eb62715a39242c"
-  dependencies:
-    "@webassemblyjs/ast" "1.5.8"
-    "@webassemblyjs/helper-buffer" "1.5.8"
-    "@webassemblyjs/wasm-gen" "1.5.8"
-    "@webassemblyjs/wasm-parser" "1.5.8"
-    debug "^3.1.0"
-
-"@webassemblyjs/wasm-parser@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.5.8.tgz#a258a7fd15bd57597e4211d9068639807546555b"
-  dependencies:
-    "@webassemblyjs/ast" "1.5.8"
-    "@webassemblyjs/helper-api-error" "1.5.8"
-    "@webassemblyjs/helper-wasm-bytecode" "1.5.8"
-    "@webassemblyjs/leb128" "1.5.8"
-    "@webassemblyjs/wasm-parser" "1.5.8"
-
-"@webassemblyjs/wast-parser@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.5.8.tgz#85705659e15d19b89af38a8d6803d720bb0493cf"
-  dependencies:
-    "@webassemblyjs/ast" "1.5.8"
-    "@webassemblyjs/floating-point-hex-parser" "1.5.8"
-    "@webassemblyjs/helper-api-error" "1.5.8"
-    "@webassemblyjs/helper-code-frame" "1.5.8"
-    "@webassemblyjs/helper-fsm" "1.5.8"
-    long "^3.2.0"
-    mamacro "^0.0.3"
-
-"@webassemblyjs/wast-printer@1.5.8":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.5.8.tgz#0f83aa67eddf377dd1d6205d4a4ac976db60e1f6"
-  dependencies:
-    "@webassemblyjs/ast" "1.5.8"
-    "@webassemblyjs/wast-parser" "1.5.8"
->>>>>>> Upgrade dependencies
     long "^3.2.0"
 
 abab@^1.0.4:
@@ -1636,21 +1269,12 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-<<<<<<< HEAD
 babel-jest@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.0.0.tgz#0e383a2aa6b3535e197db2929570a2182bd084e8"
   dependencies:
     babel-plugin-istanbul "^4.1.6"
     babel-preset-jest "^23.0.0"
-=======
-babel-jest@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.0.1.tgz#bbad3bf523fb202da05ed0a6540b48c84eed13a6"
-  dependencies:
-    babel-plugin-istanbul "^4.1.6"
-    babel-preset-jest "^23.0.1"
->>>>>>> Upgrade dependencies
 
 babel-loader@^8.0.0-beta.0:
   version "8.0.0-beta.2"
@@ -1681,15 +1305,9 @@ babel-plugin-istanbul@^4.1.6:
     istanbul-lib-instrument "^1.10.1"
     test-exclude "^4.2.1"
 
-<<<<<<< HEAD
 babel-plugin-jest-hoist@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.0.tgz#e61e68799f743391a1e6306ee270477aacf946c8"
-=======
-babel-plugin-jest-hoist@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.1.tgz#eaa11c964563aea9c21becef2bdf7853f7f3c148"
->>>>>>> Upgrade dependencies
 
 babel-plugin-syntax-dynamic-import@^6.18.0:
   version "6.18.0"
@@ -1703,19 +1321,11 @@ babel-plugin-transform-cup-globals@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-cup-globals/-/babel-plugin-transform-cup-globals-1.0.1.tgz#d4edfd5d629932d0e5467a2b65987baa6da22a9b"
 
-<<<<<<< HEAD
 babel-preset-jest@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.0.0.tgz#49de0303f1b6875dcad6163eaa7eb8330d54824d"
   dependencies:
     babel-plugin-jest-hoist "^23.0.0"
-=======
-babel-preset-jest@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.0.1.tgz#631cc545c6cf021943013bcaf22f45d87fe62198"
-  dependencies:
-    babel-plugin-jest-hoist "^23.0.1"
->>>>>>> Upgrade dependencies
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-register@^6.26.0:
@@ -2168,13 +1778,6 @@ chrome-remote-interface@^0.25.6:
     commander "2.11.x"
     ws "3.3.x"
 
-chrome-remote-interface@^0.25.6:
-  version "0.25.6"
-  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.25.6.tgz#172bc82d87091a2ae90711a7b6c940da64ce32ef"
-  dependencies:
-    commander "2.11.x"
-    ws "3.3.x"
-
 chrome-trace-event@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-0.1.2.tgz#90f36885d5345a50621332f0717b595883d5d982"
@@ -2422,9 +2025,9 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
-core-js@^2.5.7:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+core-js@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2893,11 +2496,7 @@ enzyme-adapter-utils@^1.1.0, enzyme-adapter-utils@^1.3.0:
     object.assign "^4.0.4"
     prop-types "^15.6.0"
 
-<<<<<<< HEAD
 enzyme-to-json@^3.3.4:
-=======
-enzyme-to-json@3.3.4:
->>>>>>> Upgrade dependencies
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.4.tgz#67c6040e931182f183418af2eb9f4323258aa77f"
   dependencies:
@@ -2997,15 +2596,9 @@ eslint-config-cup@^1.0.0-rc.4:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-cup/-/eslint-config-cup-1.0.0.tgz#0fcdb787fe254fc9458ec5258143cb0d47052896"
 
-<<<<<<< HEAD
 eslint-config-fusion@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-fusion/-/eslint-config-fusion-2.0.0.tgz#a3063e42622c21d8b18889160e627facc1cb23b5"
-=======
-eslint-config-fusion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-fusion/-/eslint-config-fusion-2.0.1.tgz#5dad369a88705ca4c94590b9b0f1d3d4f6520e92"
->>>>>>> Upgrade dependencies
   dependencies:
     eslint-config-uber-universal-stage-3 "^1.0.0-rc.7"
 
@@ -3054,7 +2647,6 @@ eslint-plugin-cup@1.0.2:
   dependencies:
     globals "^11.5.0"
 
-<<<<<<< HEAD
 eslint-plugin-flowtype@^2.47.1:
   version "2.47.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.47.1.tgz#1be0d6b855dbf8f253fcf49ea3d44bf6c23ff984"
@@ -3062,15 +2654,6 @@ eslint-plugin-flowtype@^2.47.1:
     lodash "^4.17.10"
 
 eslint-plugin-import@^2.12.0:
-=======
-eslint-plugin-flowtype@2.48.0:
-  version "2.48.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.48.0.tgz#e447dc27dcb99d68e2a705fd9c1046c32aae2ca1"
-  dependencies:
-    lodash "^4.17.10"
-
-eslint-plugin-import@2.12.0:
->>>>>>> Upgrade dependencies
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz#dad31781292d6664b25317fd049d2e2b2f02205d"
   dependencies:
@@ -3092,11 +2675,7 @@ eslint-plugin-prettier@2.6.0:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
-<<<<<<< HEAD
 eslint-plugin-react@^7.8.2:
-=======
-eslint-plugin-react@7.8.2:
->>>>>>> Upgrade dependencies
   version "7.8.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.8.2.tgz#e95c9c47fece55d2303d1a67c9d01b930b88a51d"
   dependencies:
@@ -3277,7 +2856,6 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-<<<<<<< HEAD
 expect@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-23.0.0.tgz#2c3ab0a44dae319e00a73e3561762768d03a2b27"
@@ -3286,16 +2864,6 @@ expect@^23.0.0:
     jest-diff "^23.0.0"
     jest-get-type "^22.1.0"
     jest-matcher-utils "^23.0.0"
-=======
-expect@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-23.0.1.tgz#99131f2fd9115595f8cc3697401e7f0734d45fef"
-  dependencies:
-    ansi-styles "^3.2.0"
-    jest-diff "^23.0.1"
-    jest-get-type "^22.1.0"
-    jest-matcher-utils "^23.0.1"
->>>>>>> Upgrade dependencies
     jest-message-util "^23.0.0"
     jest-regex-util "^23.0.0"
 
@@ -4184,7 +3752,7 @@ iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-ieee754@^1.1.11, ieee754@^1.1.4:
+ieee754@^1.1.4:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.11.tgz#c16384ffe00f5b7835824e67b6f2bd44a5229455"
 
@@ -4628,11 +4196,7 @@ istanbul-lib-hook@^1.2.0:
   dependencies:
     append-transform "^0.4.0"
 
-<<<<<<< HEAD
 istanbul-lib-instrument@^1.10.1:
-=======
-istanbul-lib-instrument@^1.10.0, istanbul-lib-instrument@^1.10.1:
->>>>>>> Upgrade dependencies
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
   dependencies:
@@ -4653,19 +4217,6 @@ istanbul-lib-report@^1.1.4:
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-<<<<<<< HEAD
-=======
-istanbul-lib-source-maps@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
-  dependencies:
-    debug "^3.1.0"
-    istanbul-lib-coverage "^1.1.2"
-    mkdirp "^0.5.1"
-    rimraf "^2.6.1"
-    source-map "^0.5.3"
-
->>>>>>> Upgrade dependencies
 istanbul-lib-source-maps@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz#cc7ccad61629f4efff8e2f78adb8c522c9976ec7"
@@ -4682,7 +4233,6 @@ istanbul-reports@^1.3.0:
   dependencies:
     handlebars "^4.0.3"
 
-<<<<<<< HEAD
 jest-changed-files@^22.2.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.4.3.tgz#8882181e022c38bd46a2e4d18d44d19d90a90fb2"
@@ -4692,23 +4242,6 @@ jest-changed-files@^22.2.0:
 jest-cli@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.0.0.tgz#29287498c9d844dcda5aaf011a4c82f9a888836e"
-=======
-istanbul-reports@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.4.0.tgz#3d7b44b912ecbe7652a603662b962120739646a1"
-  dependencies:
-    handlebars "^4.0.3"
-
-jest-changed-files@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.0.1.tgz#f79572d0720844ea5df84c2a448e862c2254f60c"
-  dependencies:
-    throat "^4.0.0"
-
-jest-cli@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.0.1.tgz#351a5ba51cf28ecf20336d97a30b970d1f530a56"
->>>>>>> Upgrade dependencies
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
@@ -4721,7 +4254,6 @@ jest-cli@^23.0.1:
     istanbul-lib-coverage "^1.2.0"
     istanbul-lib-instrument "^1.10.1"
     istanbul-lib-source-maps "^1.2.4"
-<<<<<<< HEAD
     jest-changed-files "^22.2.0"
     jest-config "^23.0.0"
     jest-environment-jsdom "^23.0.0"
@@ -4736,22 +4268,6 @@ jest-cli@^23.0.1:
     jest-util "^23.0.0"
     jest-validate "^23.0.0"
     jest-worker "^23.0.0"
-=======
-    jest-changed-files "^23.0.1"
-    jest-config "^23.0.1"
-    jest-environment-jsdom "^23.0.1"
-    jest-get-type "^22.1.0"
-    jest-haste-map "^23.0.1"
-    jest-message-util "^23.0.0"
-    jest-regex-util "^23.0.0"
-    jest-resolve-dependencies "^23.0.1"
-    jest-runner "^23.0.1"
-    jest-runtime "^23.0.1"
-    jest-snapshot "^23.0.1"
-    jest-util "^23.0.1"
-    jest-validate "^23.0.1"
-    jest-worker "^23.0.1"
->>>>>>> Upgrade dependencies
     micromatch "^2.3.11"
     node-notifier "^5.2.1"
     realpath-native "^1.0.0"
@@ -4762,7 +4278,6 @@ jest-cli@^23.0.1:
     which "^1.2.12"
     yargs "^11.0.0"
 
-<<<<<<< HEAD
 jest-config@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.0.0.tgz#9444d858873ad567376f8cfe139fd8828e8d494b"
@@ -4784,44 +4299,16 @@ jest-config@^23.0.0:
 jest-diff@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.0.0.tgz#0a00b2157f518eec338121ccf8879c529269a88e"
-=======
-jest-config@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.0.1.tgz#6798bff1247c7a390b1327193305001582fc58fa"
-  dependencies:
-    babel-core "^6.0.0"
-    babel-jest "^23.0.1"
-    chalk "^2.0.1"
-    glob "^7.1.1"
-    jest-environment-jsdom "^23.0.1"
-    jest-environment-node "^23.0.1"
-    jest-get-type "^22.1.0"
-    jest-jasmine2 "^23.0.1"
-    jest-regex-util "^23.0.0"
-    jest-resolve "^23.0.1"
-    jest-util "^23.0.1"
-    jest-validate "^23.0.1"
-    pretty-format "^23.0.1"
-
-jest-diff@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.0.1.tgz#3d49137cee12c320a4b4d2b4a6fa6e82d491a16a"
->>>>>>> Upgrade dependencies
   dependencies:
     chalk "^2.0.1"
     diff "^3.2.0"
     jest-get-type "^22.1.0"
-<<<<<<< HEAD
     pretty-format "^23.0.0"
-=======
-    pretty-format "^23.0.1"
->>>>>>> Upgrade dependencies
 
 jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
-<<<<<<< HEAD
 jest-docblock@^22.4.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.4.3.tgz#50886f132b42b280c903c592373bb6e93bb68b19"
@@ -4843,41 +4330,10 @@ jest-environment-node@^23.0.0:
     jest-mock "^23.0.0"
     jest-util "^23.0.0"
 
-=======
-jest-docblock@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.0.1.tgz#deddd18333be5dc2415260a04ef3fce9276b5725"
-  dependencies:
-    detect-newline "^2.1.0"
-
-jest-each@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.0.1.tgz#a6e5dbf530afc6bf9d74792dde69d8db70f84706"
-  dependencies:
-    chalk "^2.0.1"
-    pretty-format "^23.0.1"
-
-jest-environment-jsdom@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.0.1.tgz#da689eb9358dc16e5708abb208f4eb26a439575c"
-  dependencies:
-    jest-mock "^23.0.1"
-    jest-util "^23.0.1"
-    jsdom "^11.5.1"
-
-jest-environment-node@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.0.1.tgz#676b740e205f1f2be77241969e7812be824ee795"
-  dependencies:
-    jest-mock "^23.0.1"
-    jest-util "^23.0.1"
-
->>>>>>> Upgrade dependencies
 jest-get-type@^22.1.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
 
-<<<<<<< HEAD
 jest-haste-map@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.0.0.tgz#09be1c9a37c16b2e2f25398864eb2806d309ca96"
@@ -4918,49 +4374,6 @@ jest-matcher-utils@^23.0.0:
     chalk "^2.0.1"
     jest-get-type "^22.1.0"
     pretty-format "^23.0.0"
-=======
-jest-haste-map@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.0.1.tgz#cd89052abfc8cba01f560bbec09d4f36aec25d4f"
-  dependencies:
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.1.11"
-    jest-docblock "^23.0.1"
-    jest-serializer "^23.0.1"
-    jest-worker "^23.0.1"
-    micromatch "^2.3.11"
-    sane "^2.0.0"
-
-jest-jasmine2@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.0.1.tgz#16d875356e6360872bba48426f7d31fdc1b0bcea"
-  dependencies:
-    chalk "^2.0.1"
-    co "^4.6.0"
-    expect "^23.0.1"
-    is-generator-fn "^1.0.0"
-    jest-diff "^23.0.1"
-    jest-each "^23.0.1"
-    jest-matcher-utils "^23.0.1"
-    jest-message-util "^23.0.0"
-    jest-snapshot "^23.0.1"
-    jest-util "^23.0.1"
-    pretty-format "^23.0.1"
-
-jest-leak-detector@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.0.1.tgz#9dba07505ac3495c39d3ec09ac1e564599e861a0"
-  dependencies:
-    pretty-format "^23.0.1"
-
-jest-matcher-utils@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz#0c6c0daedf9833c2a7f36236069efecb4c3f6e5f"
-  dependencies:
-    chalk "^2.0.1"
-    jest-get-type "^22.1.0"
-    pretty-format "^23.0.1"
->>>>>>> Upgrade dependencies
 
 jest-message-util@^23.0.0:
   version "23.0.0"
@@ -4972,21 +4385,14 @@ jest-message-util@^23.0.0:
     slash "^1.0.0"
     stack-utils "^1.0.1"
 
-<<<<<<< HEAD
 jest-mock@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.0.0.tgz#d9d897a1b74dc05c66a737213931496215897dd8"
-=======
-jest-mock@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.0.1.tgz#1569f477968c668fc728273a17c3767773b46357"
->>>>>>> Upgrade dependencies
 
 jest-regex-util@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.0.0.tgz#dd5c1fde0c46f4371314cf10f7a751a23f4e8f76"
 
-<<<<<<< HEAD
 jest-resolve-dependencies@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.0.tgz#c3e1cfee0e543dee10e6ec0628df69cd239244c9"
@@ -4997,24 +4403,11 @@ jest-resolve-dependencies@^23.0.0:
 jest-resolve@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.0.0.tgz#f04362fd0531b4546399df76c55c3214a9f45e02"
-=======
-jest-resolve-dependencies@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.1.tgz#d01a10ddad9152c4cecdf5eac2b88571c4b6a64d"
-  dependencies:
-    jest-regex-util "^23.0.0"
-    jest-snapshot "^23.0.1"
-
-jest-resolve@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.0.1.tgz#3f8403462b10a34c2df1d47aab5574c4935bcd24"
->>>>>>> Upgrade dependencies
   dependencies:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
     realpath-native "^1.0.0"
 
-<<<<<<< HEAD
 jest-runner@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.0.0.tgz#b198a2dd78d57a2c0f3f8d7c7f97b62673922020"
@@ -5036,38 +4429,13 @@ jest-runner@^23.0.0:
 jest-runtime@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.0.0.tgz#8619227fe2e01603d542b9101dd3e64ef4593f66"
-=======
-jest-runner@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.0.1.tgz#b176ae3ecf9e194aa4b84a7fcf70d1b8db231aa7"
-  dependencies:
-    exit "^0.1.2"
-    graceful-fs "^4.1.11"
-    jest-config "^23.0.1"
-    jest-docblock "^23.0.1"
-    jest-haste-map "^23.0.1"
-    jest-jasmine2 "^23.0.1"
-    jest-leak-detector "^23.0.1"
-    jest-message-util "^23.0.0"
-    jest-runtime "^23.0.1"
-    jest-util "^23.0.1"
-    jest-worker "^23.0.1"
-    source-map-support "^0.5.6"
-    throat "^4.0.0"
-
-jest-runtime@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.0.1.tgz#b1d765fb03fb6d4043805af270676a693f504d57"
->>>>>>> Upgrade dependencies
   dependencies:
     babel-core "^6.0.0"
     babel-plugin-istanbul "^4.1.6"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
     exit "^0.1.2"
-    fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.1.11"
-<<<<<<< HEAD
     jest-config "^23.0.0"
     jest-haste-map "^23.0.0"
     jest-message-util "^23.0.0"
@@ -5077,16 +4445,6 @@ jest-runtime@^23.0.1:
     jest-util "^23.0.0"
     jest-validate "^23.0.0"
     json-stable-stringify "^1.0.1"
-=======
-    jest-config "^23.0.1"
-    jest-haste-map "^23.0.1"
-    jest-message-util "^23.0.0"
-    jest-regex-util "^23.0.0"
-    jest-resolve "^23.0.1"
-    jest-snapshot "^23.0.1"
-    jest-util "^23.0.1"
-    jest-validate "^23.0.1"
->>>>>>> Upgrade dependencies
     micromatch "^2.3.11"
     realpath-native "^1.0.0"
     slash "^1.0.0"
@@ -5094,7 +4452,6 @@ jest-runtime@^23.0.1:
     write-file-atomic "^2.1.0"
     yargs "^11.0.0"
 
-<<<<<<< HEAD
 jest-serializer@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.0.tgz#263411ac92e1e3dde243858642bb04e8a986e8ca"
@@ -5113,26 +4470,6 @@ jest-snapshot@^23.0.0:
 jest-util@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.0.0.tgz#86386800ffbe3fe17a06320e0cf9ca9b7868263b"
-=======
-jest-serializer@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
-
-jest-snapshot@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.0.1.tgz#6674fa19b9eb69a99cabecd415bddc42d6af3e7e"
-  dependencies:
-    chalk "^2.0.1"
-    jest-diff "^23.0.1"
-    jest-matcher-utils "^23.0.1"
-    mkdirp "^0.5.1"
-    natural-compare "^1.4.0"
-    pretty-format "^23.0.1"
-
-jest-util@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.0.1.tgz#68ea5bd7edb177d3059f9797259f8e0dacce2f99"
->>>>>>> Upgrade dependencies
   dependencies:
     callsites "^2.0.0"
     chalk "^2.0.1"
@@ -5142,20 +4479,13 @@ jest-util@^23.0.1:
     mkdirp "^0.5.1"
     source-map "^0.6.0"
 
-<<<<<<< HEAD
 jest-validate@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.0.0.tgz#f88bc897b6cc376979aff0262d1025df1302d520"
-=======
-jest-validate@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.0.1.tgz#cd9f01a89d26bb885f12a8667715e9c865a5754f"
->>>>>>> Upgrade dependencies
   dependencies:
     chalk "^2.0.1"
     jest-get-type "^22.1.0"
     leven "^2.1.0"
-<<<<<<< HEAD
     pretty-format "^23.0.0"
 
 jest-worker@^23.0.0:
@@ -5170,30 +4500,6 @@ jest@^23.0.0:
   dependencies:
     import-local "^1.0.0"
     jest-cli "^23.0.0"
-=======
-    pretty-format "^23.0.1"
-
-jest-worker@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.0.1.tgz#9e649dd963ff4046026f91c4017f039a6aa4a7bc"
-  dependencies:
-    merge-stream "^1.0.1"
-
-jest@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-23.0.1.tgz#0d083290ee4112cecfb780df6ff81332ed373201"
-  dependencies:
-    import-local "^1.0.0"
-    jest-cli "^23.0.1"
-
-jpeg-js@0.1.2, jpeg-js@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.1.2.tgz#135b992c0575c985cfa0f494a3227ed238583ece"
-
-js-library-detector@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-4.3.1.tgz#6d34f55002813bc0a7543deef53faa4e2e79767b"
->>>>>>> Upgrade dependencies
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -5388,16 +4694,6 @@ koa-send@^4.1.3:
 koa-static@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/koa-static/-/koa-static-4.0.3.tgz#5f93ad00fb1905db9ce46667c0e8bb7d22abfcd8"
-<<<<<<< HEAD
-=======
-  dependencies:
-    debug "^3.1.0"
-    koa-send "^4.1.3"
-
-koa-webpack-hot-middleware@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/koa-webpack-hot-middleware/-/koa-webpack-hot-middleware-1.0.3.tgz#df6aafbf2d77153101e37e6a4ae70235b466f8c0"
->>>>>>> Upgrade dependencies
   dependencies:
     debug "^3.1.0"
     koa-send "^4.1.3"
@@ -5556,10 +4852,6 @@ makeerror@1.0.x:
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
-
-mamacro@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -6028,41 +5320,6 @@ nwmatcher@^1.4.3:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
 
-<<<<<<< HEAD
-=======
-nyc@^11.8.0:
-  version "11.8.0"
-  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.8.0.tgz#1e8453b0644f8fea4d829b1a6636663157cd3b00"
-  dependencies:
-    archy "^1.0.0"
-    arrify "^1.0.1"
-    caching-transform "^1.0.0"
-    convert-source-map "^1.5.1"
-    debug-log "^1.0.1"
-    default-require-extensions "^1.0.0"
-    find-cache-dir "^0.1.1"
-    find-up "^2.1.0"
-    foreground-child "^1.5.3"
-    glob "^7.0.6"
-    istanbul-lib-coverage "^1.1.2"
-    istanbul-lib-hook "^1.1.0"
-    istanbul-lib-instrument "^1.10.0"
-    istanbul-lib-report "^1.1.3"
-    istanbul-lib-source-maps "^1.2.3"
-    istanbul-reports "^1.4.0"
-    md5-hex "^1.2.0"
-    merge-source-map "^1.1.0"
-    micromatch "^3.1.10"
-    mkdirp "^0.5.0"
-    resolve-from "^2.0.0"
-    rimraf "^2.6.2"
-    signal-exit "^3.0.1"
-    spawn-wrap "^1.4.2"
-    test-exclude "^4.2.0"
-    yargs "11.1.0"
-    yargs-parser "^8.0.0"
-
->>>>>>> Upgrade dependencies
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
@@ -6468,7 +5725,6 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-<<<<<<< HEAD
 prettier@1.13.5:
   version "1.13.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.5.tgz#7ae2076998c8edce79d63834e9b7b09fead6bfd0"
@@ -6476,15 +5732,6 @@ prettier@1.13.5:
 pretty-format@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.0.0.tgz#b66dc584a0907b1969783c4c20e4d1180b18ac75"
-=======
-prettier@1.13.2:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.2.tgz#412b87bc561cb11074d2877a33a38f78c2303cda"
-
-pretty-format@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.0.1.tgz#d61d065268e4c759083bccbca27a01ad7c7601f4"
->>>>>>> Upgrade dependencies
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -6721,11 +5968,7 @@ react-dev-utils@^5.0.1:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-<<<<<<< HEAD
 react-dom@^16.4.0:
-=======
-react-dom@16.4.0:
->>>>>>> Upgrade dependencies
   version "16.4.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.0.tgz#099f067dd5827ce36a29eaf9a6cdc7cbf6216b1e"
   dependencies:
@@ -6778,23 +6021,13 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
-<<<<<<< HEAD
 react-test-renderer@^16.0.0-0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
-=======
-react-test-renderer@16.4.0:
-  version "16.4.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.0.tgz#0dbe0e24263e94e1830c7afb1f403707fad313a3"
->>>>>>> Upgrade dependencies
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
-<<<<<<< HEAD
-=======
-    react-is "^16.4.0"
->>>>>>> Upgrade dependencies
 
 react-test-renderer@^16.4.0:
   version "16.4.0"
@@ -6805,11 +6038,7 @@ react-test-renderer@^16.4.0:
     prop-types "^15.6.0"
     react-is "^16.4.0"
 
-<<<<<<< HEAD
 react@^16.4.0:
-=======
-react@16.4.0:
->>>>>>> Upgrade dependencies
   version "16.4.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.4.0.tgz#402c2db83335336fba1962c08b98c6272617d585"
   dependencies:
@@ -6951,27 +6180,6 @@ regexpu-core@^4.1.3:
 regexpu-core@^4.1.4:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.1.5.tgz#57fdfe1148f8a7a069086228515130cf1820ddd0"
-<<<<<<< HEAD
-=======
-  dependencies:
-    regenerate "^1.4.0"
-    regenerate-unicode-properties "^6.0.0"
-    regjsgen "^0.4.0"
-    regjsparser "^0.3.0"
-    unicode-match-property-ecmascript "^1.0.3"
-    unicode-match-property-value-ecmascript "^1.0.1"
-
-registry-auth-token@^3.0.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
-  dependencies:
-    rc "^1.1.6"
-    safe-buffer "^5.0.1"
-
-registry-url@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
->>>>>>> Upgrade dependencies
   dependencies:
     regenerate "^1.4.0"
     regenerate-unicode-properties "^6.0.0"
@@ -7865,24 +7073,7 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
-<<<<<<< HEAD
 test-exclude@^4.2.1:
-=======
-temp@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
-  dependencies:
-    os-tmpdir "^1.0.0"
-    rimraf "~2.2.6"
-
-term-size@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
-  dependencies:
-    execa "^0.7.0"
-
-test-exclude@^4.2.0, test-exclude@^4.2.1:
->>>>>>> Upgrade dependencies
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
   dependencies:
@@ -8254,7 +7445,6 @@ watchpack@^1.5.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
-<<<<<<< HEAD
 webassemblyjs@1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webassemblyjs/-/webassemblyjs-1.4.3.tgz#0591893efb8fbde74498251cbe4b2d83df9239cb"
@@ -8264,81 +7454,11 @@ webassemblyjs@1.4.3:
     "@webassemblyjs/wasm-parser" "1.4.3"
     "@webassemblyjs/wast-parser" "1.4.3"
     long "^3.2.0"
-=======
-wbuf@^1.1.0, wbuf@^1.7.2:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
-  dependencies:
-    minimalistic-assert "^1.0.0"
->>>>>>> Upgrade dependencies
 
 webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
-<<<<<<< HEAD
-=======
-webpack-chunk-hash@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/webpack-chunk-hash/-/webpack-chunk-hash-0.6.0.tgz#eca36aff76e327d08a18a3e7990eb46e68376818"
-  dependencies:
-    "@types/webpack" "^3.0.0 || ^4.0.0"
-
-webpack-dev-middleware@3.1.3, webpack-dev-middleware@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.1.3.tgz#8b32aa43da9ae79368c1bf1183f2b6cf5e1f39ed"
-  dependencies:
-    loud-rejection "^1.6.0"
-    memory-fs "~0.4.1"
-    mime "^2.1.0"
-    path-is-absolute "^1.0.0"
-    range-parser "^1.0.3"
-    url-join "^4.0.0"
-    webpack-log "^1.0.1"
-
-webpack-dev-server@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.1.4.tgz#9a08d13c4addd1e3b6d8ace116e86715094ad5b4"
-  dependencies:
-    ansi-html "0.0.7"
-    array-includes "^3.0.3"
-    bonjour "^3.5.0"
-    chokidar "^2.0.0"
-    compression "^1.5.2"
-    connect-history-api-fallback "^1.3.0"
-    debug "^3.1.0"
-    del "^3.0.0"
-    express "^4.16.2"
-    html-entities "^1.2.0"
-    http-proxy-middleware "~0.18.0"
-    import-local "^1.0.0"
-    internal-ip "1.2.0"
-    ip "^1.1.5"
-    killable "^1.0.0"
-    loglevel "^1.4.1"
-    opn "^5.1.0"
-    portfinder "^1.0.9"
-    selfsigned "^1.9.1"
-    serve-index "^1.7.2"
-    sockjs "0.3.19"
-    sockjs-client "1.1.4"
-    spdy "^3.4.1"
-    strip-ansi "^3.0.0"
-    supports-color "^5.1.0"
-    webpack-dev-middleware "3.1.3"
-    webpack-log "^1.1.2"
-    yargs "11.0.0"
-
-webpack-hot-middleware@2.x:
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.21.2.tgz#2e2aa65563b8b32546b67e53b5a9667dcd80f327"
-  dependencies:
-    ansi-html "0.0.7"
-    html-entities "^1.2.0"
-    querystring "^0.2.0"
-    strip-ansi "^3.0.0"
-
->>>>>>> Upgrade dependencies
 webpack-hot-middleware@^2.22.2:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.22.2.tgz#623b77ce591fcd4e1fb99f18167781443e50afac"
@@ -8355,7 +7475,6 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-<<<<<<< HEAD
 webpack@^4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.9.0.tgz#a795fd0fad72205faa46bdca09ffaa36f4446262"
@@ -8363,16 +7482,6 @@ webpack@^4.9.0:
     "@webassemblyjs/ast" "1.4.3"
     "@webassemblyjs/wasm-edit" "1.4.3"
     "@webassemblyjs/wasm-parser" "1.4.3"
-=======
-webpack@^4.10.1:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.10.1.tgz#74909fb9c32941b5c34d22c1f8782c9a033a52e7"
-  dependencies:
-    "@webassemblyjs/ast" "1.5.8"
-    "@webassemblyjs/wasm-edit" "1.5.8"
-    "@webassemblyjs/wasm-opt" "1.5.8"
-    "@webassemblyjs/wasm-parser" "1.5.8"
->>>>>>> Upgrade dependencies
     acorn "^5.0.0"
     acorn-dynamic-import "^3.0.0"
     ajv "^6.1.0"
@@ -8536,21 +7645,6 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-<<<<<<< HEAD
-=======
-yargs-parser@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
-  dependencies:
-    camelcase "^4.1.0"
-
-yargs-parser@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
-  dependencies:
-    camelcase "^4.1.0"
-
->>>>>>> Upgrade dependencies
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
@@ -8574,38 +7668,6 @@ yargs@^11.0.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-<<<<<<< HEAD
-=======
-yargs@11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^9.0.2"
-
-yargs@3.32.0:
-  version "3.32.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
-  dependencies:
-    camelcase "^2.0.1"
-    cliui "^3.0.3"
-    decamelize "^1.1.1"
-    os-locale "^1.4.0"
-    string-width "^1.0.1"
-    window-size "^0.1.4"
-    y18n "^3.2.0"
-
->>>>>>> Upgrade dependencies
 yargs@~3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,6 +73,7 @@
     "@babel/helper-explode-assignable-expression" "7.0.0-beta.49"
     "@babel/types" "7.0.0-beta.49"
 
+<<<<<<< HEAD
 "@babel/helper-builder-react-jsx@7.0.0-beta.48":
   version "7.0.0-beta.48"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.48.tgz#bdfd701514382c495a879f11d4aab835e86a7740"
@@ -99,6 +100,27 @@
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.49.tgz#4ea067aa720937240df395cd073c24fcad9c2b3b"
   dependencies:
+=======
+"@babel/helper-builder-react-jsx@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.49.tgz#e6c35f8c88e90093139fa7b3027d05cceb47f43d"
+  dependencies:
+    "@babel/types" "7.0.0-beta.49"
+    esutils "^2.0.0"
+
+"@babel/helper-call-delegate@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.49.tgz#4b5d41782a683d5dc6497834a32310a8d02a3af9"
+  dependencies:
+    "@babel/helper-hoist-variables" "7.0.0-beta.49"
+    "@babel/traverse" "7.0.0-beta.49"
+    "@babel/types" "7.0.0-beta.49"
+
+"@babel/helper-define-map@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.49.tgz#4ea067aa720937240df395cd073c24fcad9c2b3b"
+  dependencies:
+>>>>>>> Upgrade dependencies
     "@babel/helper-function-name" "7.0.0-beta.49"
     "@babel/types" "7.0.0-beta.49"
     lodash "^4.17.5"
@@ -173,10 +195,13 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.49.tgz#a98b43c3a6c54bef48f87b10dc4568dec0b41bf7"
   dependencies:
     "@babel/types" "7.0.0-beta.49"
+<<<<<<< HEAD
 
 "@babel/helper-plugin-utils@7.0.0-beta.48":
   version "7.0.0-beta.48"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.48.tgz#bf310f89e91d146ac0f1369562164be45edba587"
+=======
+>>>>>>> Upgrade dependencies
 
 "@babel/helper-plugin-utils@7.0.0-beta.49":
   version "7.0.0-beta.49"
@@ -272,6 +297,7 @@
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.49.tgz#944d0c5ba2812bb159edbd226743afd265179bdc"
 
+<<<<<<< HEAD
 "@babel/plugin-proposal-async-generator-functions@7.0.0-beta.49":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.49.tgz#8761a5e2d8b5251e70df28f4d0aa64aa28a596b1"
@@ -342,6 +368,78 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.48.tgz#c8bf06aa238009fd0ae01d5d490b7b455a5e6295"
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.48"
+=======
+"@babel/plugin-external-helpers@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0-beta.49.tgz#c67ffa9e23d7063810b0d4304857bf5c16f8a35b"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-proposal-async-generator-functions@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.49.tgz#8761a5e2d8b5251e70df28f4d0aa64aa28a596b1"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/helper-remap-async-to-generator" "7.0.0-beta.49"
+    "@babel/plugin-syntax-async-generators" "7.0.0-beta.49"
+
+"@babel/plugin-proposal-class-properties@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.49.tgz#527e90af75d23fd5e3bae1a218dc0a6d9236b5f1"
+  dependencies:
+    "@babel/helper-function-name" "7.0.0-beta.49"
+    "@babel/helper-member-expression-to-functions" "7.0.0-beta.49"
+    "@babel/helper-optimise-call-expression" "7.0.0-beta.49"
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/helper-replace-supers" "7.0.0-beta.49"
+    "@babel/plugin-syntax-class-properties" "7.0.0-beta.49"
+
+"@babel/plugin-proposal-object-rest-spread@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.49.tgz#6d0cd60f7a7bd7c444a371c4e9470bff02f5777c"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.49"
+
+"@babel/plugin-proposal-optional-catch-binding@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.49.tgz#1f53d36785101d5eb4b55d65686aa2b39fa21c4b"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.49"
+
+"@babel/plugin-proposal-unicode-property-regex@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.49.tgz#0ef5fb9abda980cd1585ef4c8e8f680b63263c72"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/helper-regex" "7.0.0-beta.49"
+    regexpu-core "^4.1.4"
+
+"@babel/plugin-syntax-async-generators@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.49.tgz#50ee943002aedc9ab3a8d12292bd35dd9edb1df8"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-syntax-class-properties@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.49.tgz#6a14fa47ceaa32b53e14e6648326e52dab306904"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-syntax-dynamic-import@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.49.tgz#f0af7ac6b53676a496093d4a6e2a2ec655c07b78"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-syntax-flow@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0-beta.49.tgz#5b3f0b65ca9660534535643b82530fb1d58e63ee"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+>>>>>>> Upgrade dependencies
 
 "@babel/plugin-syntax-jsx@7.0.0-beta.49":
   version "7.0.0-beta.49"
@@ -349,7 +447,11 @@
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
 
+<<<<<<< HEAD
 "@babel/plugin-syntax-object-rest-spread@7.0.0-beta.49":
+=======
+"@babel/plugin-syntax-object-rest-spread@7.0.0-beta.49", "@babel/plugin-syntax-object-rest-spread@^7.0.0-beta.49":
+>>>>>>> Upgrade dependencies
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.49.tgz#4784b3880823ff12e742c26b41e9857f701d639e"
   dependencies:
@@ -424,6 +526,7 @@
 "@babel/plugin-transform-duplicate-keys@7.0.0-beta.49":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.49.tgz#fac244809ddecbf095e375558ccb716da1042316"
+<<<<<<< HEAD
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
 
@@ -515,6 +618,93 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.48.tgz#a4adc3bf255ffccc0beac8b9dd9c283a53bf8956"
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.48"
+=======
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-transform-exponentiation-operator@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.49.tgz#457b2d09004794684aa6e1b04015080b80a08a14"
+  dependencies:
+    "@babel/helper-builder-binary-assignment-operator-visitor" "7.0.0-beta.49"
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-transform-flow-strip-types@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0-beta.49.tgz#f02a26528e94b2c1d11d9573b63ee5782d4f2af9"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/plugin-syntax-flow" "7.0.0-beta.49"
+
+"@babel/plugin-transform-for-of@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.49.tgz#3ec72726bf1d89a0d4d511be7a9549066f57aade"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-transform-function-name@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.49.tgz#af39f60e7aefce9b25eb4adcedd04d50866ce218"
+  dependencies:
+    "@babel/helper-function-name" "7.0.0-beta.49"
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-transform-literals@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.49.tgz#07c838254d65e6867e86513eb0f22d5f26b0a56a"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-transform-modules-amd@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.49.tgz#16d07480954b0415ea70f1ec3edbd0597bd3ddfe"
+  dependencies:
+    "@babel/helper-module-transforms" "7.0.0-beta.49"
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-transform-modules-commonjs@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.49.tgz#09fb345d5927c2ba3bd89e7cdb13a55067ed39a0"
+  dependencies:
+    "@babel/helper-module-transforms" "7.0.0-beta.49"
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/helper-simple-access" "7.0.0-beta.49"
+
+"@babel/plugin-transform-modules-systemjs@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.49.tgz#68225a3ae1312771bc5a36f71ff10d02c1243d9f"
+  dependencies:
+    "@babel/helper-hoist-variables" "7.0.0-beta.49"
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-transform-modules-umd@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.49.tgz#7048ca5a77189706f4b3e96e4b996eb30590dd63"
+  dependencies:
+    "@babel/helper-module-transforms" "7.0.0-beta.49"
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-transform-new-target@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.49.tgz#c2ffef1ebbaf724a9e58dde114e57e3e6864a5e7"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-transform-object-super@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.49.tgz#b302f55702847343c10ff4fb8435cc3574755fe3"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/helper-replace-supers" "7.0.0-beta.49"
+
+"@babel/plugin-transform-parameters@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.49.tgz#1cad71a2a33281e5efbb1a4623a964c073ce9a2d"
+  dependencies:
+    "@babel/helper-call-delegate" "7.0.0-beta.49"
+    "@babel/helper-get-function-arity" "7.0.0-beta.49"
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+>>>>>>> Upgrade dependencies
 
 "@babel/plugin-transform-react-display-name@7.0.0-beta.49":
   version "7.0.0-beta.49"
@@ -522,6 +712,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
 
+<<<<<<< HEAD
 "@babel/plugin-transform-react-jsx-self@7.0.0-beta.48":
   version "7.0.0-beta.48"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.48.tgz#fb0e87a38af96706ff642c64fa2e68be126aaf4f"
@@ -532,10 +723,23 @@
 "@babel/plugin-transform-react-jsx-self@7.0.0-beta.49":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.49.tgz#a11828ba38035c1aa93fd44099b9897019fa546c"
+=======
+"@babel/plugin-transform-react-jsx-self@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.49.tgz#a11828ba38035c1aa93fd44099b9897019fa546c"
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
     "@babel/plugin-syntax-jsx" "7.0.0-beta.49"
 
+"@babel/plugin-transform-react-jsx-source@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.49.tgz#05bb7429b6dd44cbdca69585481347a809caa8ca"
+>>>>>>> Upgrade dependencies
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/plugin-syntax-jsx" "7.0.0-beta.49"
+
+<<<<<<< HEAD
 "@babel/plugin-transform-react-jsx-source@7.0.0-beta.48":
   version "7.0.0-beta.48"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.48.tgz#8af9a9c9ae6b8515dcaa84d8f50a88e176ea5138"
@@ -566,6 +770,16 @@
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
     "@babel/plugin-syntax-jsx" "7.0.0-beta.49"
 
+=======
+"@babel/plugin-transform-react-jsx@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.49.tgz#0f2789fde305c3c14151848f8514a2af1441af58"
+  dependencies:
+    "@babel/helper-builder-react-jsx" "7.0.0-beta.49"
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/plugin-syntax-jsx" "7.0.0-beta.49"
+
+>>>>>>> Upgrade dependencies
 "@babel/plugin-transform-regenerator@7.0.0-beta.49":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.49.tgz#d4ed7967033f4f5b49363c203503899b8357cae2"
@@ -659,6 +873,7 @@
 "@babel/preset-flow@7.0.0-beta.49":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.0.0-beta.49.tgz#10cbee1a60db207120a4443c54c0ca5f734eb390"
+<<<<<<< HEAD
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
     "@babel/plugin-transform-flow-strip-types" "7.0.0-beta.49"
@@ -682,6 +897,21 @@
     "@babel/plugin-transform-react-jsx" "7.0.0-beta.48"
     "@babel/plugin-transform-react-jsx-self" "7.0.0-beta.48"
     "@babel/plugin-transform-react-jsx-source" "7.0.0-beta.48"
+=======
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/plugin-transform-flow-strip-types" "7.0.0-beta.49"
+
+"@babel/preset-react@7.0.0-beta.49", "@babel/preset-react@^7.0.0-beta.47":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.0.0-beta.49.tgz#0c86770f6e78a49af6f86942f5980beb5feb76c5"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/plugin-transform-react-display-name" "7.0.0-beta.49"
+    "@babel/plugin-transform-react-jsx" "7.0.0-beta.49"
+    "@babel/plugin-transform-react-jsx-self" "7.0.0-beta.49"
+    "@babel/plugin-transform-react-jsx-source" "7.0.0-beta.49"
+>>>>>>> Upgrade dependencies
 
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -739,6 +969,7 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+<<<<<<< HEAD
 "@babel/types@7.0.0-beta.48":
   version "7.0.0-beta.48"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.48.tgz#095872fa6f8a87846f5872a39a938f34d5dc55a3"
@@ -753,6 +984,14 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.5"
+=======
+"@babel/types@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.49.tgz#b7e3b1c3f4d4cfe11bdf8c89f1efd5e1617b87a6"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.5"
+>>>>>>> Upgrade dependencies
     to-fast-properties "^2.0.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
@@ -789,6 +1028,7 @@
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.4.3.tgz#f5aee4c376a717c74264d7bacada981e7e44faad"
 
+<<<<<<< HEAD
 "@webassemblyjs/helper-buffer@1.4.3":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.4.3.tgz#0434b55958519bf503697d3824857b1dea80b729"
@@ -890,6 +1130,133 @@
   dependencies:
     "@webassemblyjs/ast" "1.4.3"
     "@webassemblyjs/wast-parser" "1.4.3"
+=======
+"@webassemblyjs/ast@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.5.8.tgz#f75ac7e7602b7833abd5d53951baae8a07ebb5df"
+  dependencies:
+    "@webassemblyjs/helper-module-context" "1.5.8"
+    "@webassemblyjs/helper-wasm-bytecode" "1.5.8"
+    "@webassemblyjs/wast-parser" "1.5.8"
+    debug "^3.1.0"
+    mamacro "^0.0.3"
+
+"@webassemblyjs/floating-point-hex-parser@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.5.8.tgz#e0604d34fab0c910e16113720a5a3c01f558fa54"
+
+"@webassemblyjs/helper-api-error@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.5.8.tgz#f5570aff60090fae1b78a690a95d04cb021da9ca"
+
+"@webassemblyjs/helper-buffer@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.5.8.tgz#b1405e819a2c537964682fb70551796ab9602632"
+  dependencies:
+    debug "^3.1.0"
+
+"@webassemblyjs/helper-code-frame@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.5.8.tgz#6439de475720198a48fa8b4c38e41987798f73cc"
+  dependencies:
+    "@webassemblyjs/wast-printer" "1.5.8"
+
+"@webassemblyjs/helper-fsm@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.5.8.tgz#6169af3c9530cf9e89a8f3cf2970ed70e650ae4f"
+
+"@webassemblyjs/helper-module-context@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.5.8.tgz#73d0de45cebb774d465b5a66fef061f834d6c23c"
+
+"@webassemblyjs/helper-wasm-bytecode@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.5.8.tgz#60df17f72d12b07e1398756e6ebfe59c03ab2e1a"
+
+"@webassemblyjs/helper-wasm-section@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.5.8.tgz#cda7fdb6f3b7b0d215c8f92b7435d47726822f49"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.8"
+    "@webassemblyjs/helper-buffer" "1.5.8"
+    "@webassemblyjs/helper-wasm-bytecode" "1.5.8"
+    "@webassemblyjs/wasm-gen" "1.5.8"
+    debug "^3.1.0"
+
+"@webassemblyjs/ieee754@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.5.8.tgz#29383c7172e90121613d5614d532f22c19255c3b"
+  dependencies:
+    ieee754 "^1.1.11"
+
+"@webassemblyjs/leb128@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.5.8.tgz#657c48ef2537ea2921e897a50157be700bf24eac"
+  dependencies:
+    leb "^0.3.0"
+
+"@webassemblyjs/wasm-edit@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.5.8.tgz#592d3678894eaa2ee7e7c2c6a13c2a697db1aa7e"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.8"
+    "@webassemblyjs/helper-buffer" "1.5.8"
+    "@webassemblyjs/helper-wasm-bytecode" "1.5.8"
+    "@webassemblyjs/helper-wasm-section" "1.5.8"
+    "@webassemblyjs/wasm-gen" "1.5.8"
+    "@webassemblyjs/wasm-opt" "1.5.8"
+    "@webassemblyjs/wasm-parser" "1.5.8"
+    "@webassemblyjs/wast-printer" "1.5.8"
+    debug "^3.1.0"
+
+"@webassemblyjs/wasm-gen@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.5.8.tgz#e94e034a45227aaa7c481b25c1aa9a0a00ab9488"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.8"
+    "@webassemblyjs/helper-wasm-bytecode" "1.5.8"
+    "@webassemblyjs/ieee754" "1.5.8"
+    "@webassemblyjs/leb128" "1.5.8"
+
+"@webassemblyjs/wasm-opt@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.5.8.tgz#a3a0d00d98dee0f3cf2ae41084eb62715a39242c"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.8"
+    "@webassemblyjs/helper-buffer" "1.5.8"
+    "@webassemblyjs/wasm-gen" "1.5.8"
+    "@webassemblyjs/wasm-parser" "1.5.8"
+    debug "^3.1.0"
+
+"@webassemblyjs/wasm-parser@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.5.8.tgz#a258a7fd15bd57597e4211d9068639807546555b"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.8"
+    "@webassemblyjs/helper-api-error" "1.5.8"
+    "@webassemblyjs/helper-wasm-bytecode" "1.5.8"
+    "@webassemblyjs/leb128" "1.5.8"
+    "@webassemblyjs/wasm-parser" "1.5.8"
+
+"@webassemblyjs/wast-parser@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.5.8.tgz#85705659e15d19b89af38a8d6803d720bb0493cf"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.8"
+    "@webassemblyjs/floating-point-hex-parser" "1.5.8"
+    "@webassemblyjs/helper-api-error" "1.5.8"
+    "@webassemblyjs/helper-code-frame" "1.5.8"
+    "@webassemblyjs/helper-fsm" "1.5.8"
+    long "^3.2.0"
+    mamacro "^0.0.3"
+
+"@webassemblyjs/wast-printer@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.5.8.tgz#0f83aa67eddf377dd1d6205d4a4ac976db60e1f6"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.8"
+    "@webassemblyjs/wast-parser" "1.5.8"
+>>>>>>> Upgrade dependencies
     long "^3.2.0"
 
 abab@^1.0.4:
@@ -1269,12 +1636,21 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
+<<<<<<< HEAD
 babel-jest@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.0.0.tgz#0e383a2aa6b3535e197db2929570a2182bd084e8"
   dependencies:
     babel-plugin-istanbul "^4.1.6"
     babel-preset-jest "^23.0.0"
+=======
+babel-jest@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.0.1.tgz#bbad3bf523fb202da05ed0a6540b48c84eed13a6"
+  dependencies:
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.0.1"
+>>>>>>> Upgrade dependencies
 
 babel-loader@^8.0.0-beta.0:
   version "8.0.0-beta.2"
@@ -1305,9 +1681,15 @@ babel-plugin-istanbul@^4.1.6:
     istanbul-lib-instrument "^1.10.1"
     test-exclude "^4.2.1"
 
+<<<<<<< HEAD
 babel-plugin-jest-hoist@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.0.tgz#e61e68799f743391a1e6306ee270477aacf946c8"
+=======
+babel-plugin-jest-hoist@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.1.tgz#eaa11c964563aea9c21becef2bdf7853f7f3c148"
+>>>>>>> Upgrade dependencies
 
 babel-plugin-syntax-dynamic-import@^6.18.0:
   version "6.18.0"
@@ -1321,11 +1703,19 @@ babel-plugin-transform-cup-globals@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-cup-globals/-/babel-plugin-transform-cup-globals-1.0.1.tgz#d4edfd5d629932d0e5467a2b65987baa6da22a9b"
 
+<<<<<<< HEAD
 babel-preset-jest@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.0.0.tgz#49de0303f1b6875dcad6163eaa7eb8330d54824d"
   dependencies:
     babel-plugin-jest-hoist "^23.0.0"
+=======
+babel-preset-jest@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.0.1.tgz#631cc545c6cf021943013bcaf22f45d87fe62198"
+  dependencies:
+    babel-plugin-jest-hoist "^23.0.1"
+>>>>>>> Upgrade dependencies
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-register@^6.26.0:
@@ -1778,6 +2168,13 @@ chrome-remote-interface@^0.25.6:
     commander "2.11.x"
     ws "3.3.x"
 
+chrome-remote-interface@^0.25.6:
+  version "0.25.6"
+  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.25.6.tgz#172bc82d87091a2ae90711a7b6c940da64ce32ef"
+  dependencies:
+    commander "2.11.x"
+    ws "3.3.x"
+
 chrome-trace-event@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-0.1.2.tgz#90f36885d5345a50621332f0717b595883d5d982"
@@ -2025,9 +2422,9 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
-core-js@^2.5.6:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
+core-js@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2496,7 +2893,11 @@ enzyme-adapter-utils@^1.1.0, enzyme-adapter-utils@^1.3.0:
     object.assign "^4.0.4"
     prop-types "^15.6.0"
 
+<<<<<<< HEAD
 enzyme-to-json@^3.3.4:
+=======
+enzyme-to-json@3.3.4:
+>>>>>>> Upgrade dependencies
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.4.tgz#67c6040e931182f183418af2eb9f4323258aa77f"
   dependencies:
@@ -2596,9 +2997,15 @@ eslint-config-cup@^1.0.0-rc.4:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-cup/-/eslint-config-cup-1.0.0.tgz#0fcdb787fe254fc9458ec5258143cb0d47052896"
 
+<<<<<<< HEAD
 eslint-config-fusion@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-fusion/-/eslint-config-fusion-2.0.0.tgz#a3063e42622c21d8b18889160e627facc1cb23b5"
+=======
+eslint-config-fusion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-fusion/-/eslint-config-fusion-2.0.1.tgz#5dad369a88705ca4c94590b9b0f1d3d4f6520e92"
+>>>>>>> Upgrade dependencies
   dependencies:
     eslint-config-uber-universal-stage-3 "^1.0.0-rc.7"
 
@@ -2647,6 +3054,7 @@ eslint-plugin-cup@1.0.2:
   dependencies:
     globals "^11.5.0"
 
+<<<<<<< HEAD
 eslint-plugin-flowtype@^2.47.1:
   version "2.47.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.47.1.tgz#1be0d6b855dbf8f253fcf49ea3d44bf6c23ff984"
@@ -2654,6 +3062,15 @@ eslint-plugin-flowtype@^2.47.1:
     lodash "^4.17.10"
 
 eslint-plugin-import@^2.12.0:
+=======
+eslint-plugin-flowtype@2.48.0:
+  version "2.48.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.48.0.tgz#e447dc27dcb99d68e2a705fd9c1046c32aae2ca1"
+  dependencies:
+    lodash "^4.17.10"
+
+eslint-plugin-import@2.12.0:
+>>>>>>> Upgrade dependencies
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz#dad31781292d6664b25317fd049d2e2b2f02205d"
   dependencies:
@@ -2675,7 +3092,11 @@ eslint-plugin-prettier@2.6.0:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
+<<<<<<< HEAD
 eslint-plugin-react@^7.8.2:
+=======
+eslint-plugin-react@7.8.2:
+>>>>>>> Upgrade dependencies
   version "7.8.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.8.2.tgz#e95c9c47fece55d2303d1a67c9d01b930b88a51d"
   dependencies:
@@ -2856,6 +3277,7 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
+<<<<<<< HEAD
 expect@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-23.0.0.tgz#2c3ab0a44dae319e00a73e3561762768d03a2b27"
@@ -2864,6 +3286,16 @@ expect@^23.0.0:
     jest-diff "^23.0.0"
     jest-get-type "^22.1.0"
     jest-matcher-utils "^23.0.0"
+=======
+expect@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-23.0.1.tgz#99131f2fd9115595f8cc3697401e7f0734d45fef"
+  dependencies:
+    ansi-styles "^3.2.0"
+    jest-diff "^23.0.1"
+    jest-get-type "^22.1.0"
+    jest-matcher-utils "^23.0.1"
+>>>>>>> Upgrade dependencies
     jest-message-util "^23.0.0"
     jest-regex-util "^23.0.0"
 
@@ -3752,7 +4184,7 @@ iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-ieee754@^1.1.4:
+ieee754@^1.1.11, ieee754@^1.1.4:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.11.tgz#c16384ffe00f5b7835824e67b6f2bd44a5229455"
 
@@ -4196,7 +4628,11 @@ istanbul-lib-hook@^1.2.0:
   dependencies:
     append-transform "^0.4.0"
 
+<<<<<<< HEAD
 istanbul-lib-instrument@^1.10.1:
+=======
+istanbul-lib-instrument@^1.10.0, istanbul-lib-instrument@^1.10.1:
+>>>>>>> Upgrade dependencies
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
   dependencies:
@@ -4217,6 +4653,19 @@ istanbul-lib-report@^1.1.4:
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
+<<<<<<< HEAD
+=======
+istanbul-lib-source-maps@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
+  dependencies:
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.1.2"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
+>>>>>>> Upgrade dependencies
 istanbul-lib-source-maps@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz#cc7ccad61629f4efff8e2f78adb8c522c9976ec7"
@@ -4233,6 +4682,7 @@ istanbul-reports@^1.3.0:
   dependencies:
     handlebars "^4.0.3"
 
+<<<<<<< HEAD
 jest-changed-files@^22.2.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.4.3.tgz#8882181e022c38bd46a2e4d18d44d19d90a90fb2"
@@ -4242,6 +4692,23 @@ jest-changed-files@^22.2.0:
 jest-cli@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.0.0.tgz#29287498c9d844dcda5aaf011a4c82f9a888836e"
+=======
+istanbul-reports@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.4.0.tgz#3d7b44b912ecbe7652a603662b962120739646a1"
+  dependencies:
+    handlebars "^4.0.3"
+
+jest-changed-files@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.0.1.tgz#f79572d0720844ea5df84c2a448e862c2254f60c"
+  dependencies:
+    throat "^4.0.0"
+
+jest-cli@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.0.1.tgz#351a5ba51cf28ecf20336d97a30b970d1f530a56"
+>>>>>>> Upgrade dependencies
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
@@ -4254,6 +4721,7 @@ jest-cli@^23.0.0:
     istanbul-lib-coverage "^1.2.0"
     istanbul-lib-instrument "^1.10.1"
     istanbul-lib-source-maps "^1.2.4"
+<<<<<<< HEAD
     jest-changed-files "^22.2.0"
     jest-config "^23.0.0"
     jest-environment-jsdom "^23.0.0"
@@ -4268,6 +4736,22 @@ jest-cli@^23.0.0:
     jest-util "^23.0.0"
     jest-validate "^23.0.0"
     jest-worker "^23.0.0"
+=======
+    jest-changed-files "^23.0.1"
+    jest-config "^23.0.1"
+    jest-environment-jsdom "^23.0.1"
+    jest-get-type "^22.1.0"
+    jest-haste-map "^23.0.1"
+    jest-message-util "^23.0.0"
+    jest-regex-util "^23.0.0"
+    jest-resolve-dependencies "^23.0.1"
+    jest-runner "^23.0.1"
+    jest-runtime "^23.0.1"
+    jest-snapshot "^23.0.1"
+    jest-util "^23.0.1"
+    jest-validate "^23.0.1"
+    jest-worker "^23.0.1"
+>>>>>>> Upgrade dependencies
     micromatch "^2.3.11"
     node-notifier "^5.2.1"
     realpath-native "^1.0.0"
@@ -4278,6 +4762,7 @@ jest-cli@^23.0.0:
     which "^1.2.12"
     yargs "^11.0.0"
 
+<<<<<<< HEAD
 jest-config@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.0.0.tgz#9444d858873ad567376f8cfe139fd8828e8d494b"
@@ -4299,16 +4784,44 @@ jest-config@^23.0.0:
 jest-diff@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.0.0.tgz#0a00b2157f518eec338121ccf8879c529269a88e"
+=======
+jest-config@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.0.1.tgz#6798bff1247c7a390b1327193305001582fc58fa"
+  dependencies:
+    babel-core "^6.0.0"
+    babel-jest "^23.0.1"
+    chalk "^2.0.1"
+    glob "^7.1.1"
+    jest-environment-jsdom "^23.0.1"
+    jest-environment-node "^23.0.1"
+    jest-get-type "^22.1.0"
+    jest-jasmine2 "^23.0.1"
+    jest-regex-util "^23.0.0"
+    jest-resolve "^23.0.1"
+    jest-util "^23.0.1"
+    jest-validate "^23.0.1"
+    pretty-format "^23.0.1"
+
+jest-diff@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.0.1.tgz#3d49137cee12c320a4b4d2b4a6fa6e82d491a16a"
+>>>>>>> Upgrade dependencies
   dependencies:
     chalk "^2.0.1"
     diff "^3.2.0"
     jest-get-type "^22.1.0"
+<<<<<<< HEAD
     pretty-format "^23.0.0"
+=======
+    pretty-format "^23.0.1"
+>>>>>>> Upgrade dependencies
 
 jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
+<<<<<<< HEAD
 jest-docblock@^22.4.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.4.3.tgz#50886f132b42b280c903c592373bb6e93bb68b19"
@@ -4330,10 +4843,41 @@ jest-environment-node@^23.0.0:
     jest-mock "^23.0.0"
     jest-util "^23.0.0"
 
+=======
+jest-docblock@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.0.1.tgz#deddd18333be5dc2415260a04ef3fce9276b5725"
+  dependencies:
+    detect-newline "^2.1.0"
+
+jest-each@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.0.1.tgz#a6e5dbf530afc6bf9d74792dde69d8db70f84706"
+  dependencies:
+    chalk "^2.0.1"
+    pretty-format "^23.0.1"
+
+jest-environment-jsdom@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.0.1.tgz#da689eb9358dc16e5708abb208f4eb26a439575c"
+  dependencies:
+    jest-mock "^23.0.1"
+    jest-util "^23.0.1"
+    jsdom "^11.5.1"
+
+jest-environment-node@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.0.1.tgz#676b740e205f1f2be77241969e7812be824ee795"
+  dependencies:
+    jest-mock "^23.0.1"
+    jest-util "^23.0.1"
+
+>>>>>>> Upgrade dependencies
 jest-get-type@^22.1.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
 
+<<<<<<< HEAD
 jest-haste-map@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.0.0.tgz#09be1c9a37c16b2e2f25398864eb2806d309ca96"
@@ -4374,6 +4918,49 @@ jest-matcher-utils@^23.0.0:
     chalk "^2.0.1"
     jest-get-type "^22.1.0"
     pretty-format "^23.0.0"
+=======
+jest-haste-map@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.0.1.tgz#cd89052abfc8cba01f560bbec09d4f36aec25d4f"
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-docblock "^23.0.1"
+    jest-serializer "^23.0.1"
+    jest-worker "^23.0.1"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
+
+jest-jasmine2@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.0.1.tgz#16d875356e6360872bba48426f7d31fdc1b0bcea"
+  dependencies:
+    chalk "^2.0.1"
+    co "^4.6.0"
+    expect "^23.0.1"
+    is-generator-fn "^1.0.0"
+    jest-diff "^23.0.1"
+    jest-each "^23.0.1"
+    jest-matcher-utils "^23.0.1"
+    jest-message-util "^23.0.0"
+    jest-snapshot "^23.0.1"
+    jest-util "^23.0.1"
+    pretty-format "^23.0.1"
+
+jest-leak-detector@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.0.1.tgz#9dba07505ac3495c39d3ec09ac1e564599e861a0"
+  dependencies:
+    pretty-format "^23.0.1"
+
+jest-matcher-utils@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz#0c6c0daedf9833c2a7f36236069efecb4c3f6e5f"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.0.1"
+>>>>>>> Upgrade dependencies
 
 jest-message-util@^23.0.0:
   version "23.0.0"
@@ -4385,14 +4972,21 @@ jest-message-util@^23.0.0:
     slash "^1.0.0"
     stack-utils "^1.0.1"
 
+<<<<<<< HEAD
 jest-mock@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.0.0.tgz#d9d897a1b74dc05c66a737213931496215897dd8"
+=======
+jest-mock@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.0.1.tgz#1569f477968c668fc728273a17c3767773b46357"
+>>>>>>> Upgrade dependencies
 
 jest-regex-util@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.0.0.tgz#dd5c1fde0c46f4371314cf10f7a751a23f4e8f76"
 
+<<<<<<< HEAD
 jest-resolve-dependencies@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.0.tgz#c3e1cfee0e543dee10e6ec0628df69cd239244c9"
@@ -4403,11 +4997,24 @@ jest-resolve-dependencies@^23.0.0:
 jest-resolve@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.0.0.tgz#f04362fd0531b4546399df76c55c3214a9f45e02"
+=======
+jest-resolve-dependencies@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.1.tgz#d01a10ddad9152c4cecdf5eac2b88571c4b6a64d"
+  dependencies:
+    jest-regex-util "^23.0.0"
+    jest-snapshot "^23.0.1"
+
+jest-resolve@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.0.1.tgz#3f8403462b10a34c2df1d47aab5574c4935bcd24"
+>>>>>>> Upgrade dependencies
   dependencies:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
     realpath-native "^1.0.0"
 
+<<<<<<< HEAD
 jest-runner@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.0.0.tgz#b198a2dd78d57a2c0f3f8d7c7f97b62673922020"
@@ -4429,13 +5036,38 @@ jest-runner@^23.0.0:
 jest-runtime@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.0.0.tgz#8619227fe2e01603d542b9101dd3e64ef4593f66"
+=======
+jest-runner@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.0.1.tgz#b176ae3ecf9e194aa4b84a7fcf70d1b8db231aa7"
+  dependencies:
+    exit "^0.1.2"
+    graceful-fs "^4.1.11"
+    jest-config "^23.0.1"
+    jest-docblock "^23.0.1"
+    jest-haste-map "^23.0.1"
+    jest-jasmine2 "^23.0.1"
+    jest-leak-detector "^23.0.1"
+    jest-message-util "^23.0.0"
+    jest-runtime "^23.0.1"
+    jest-util "^23.0.1"
+    jest-worker "^23.0.1"
+    source-map-support "^0.5.6"
+    throat "^4.0.0"
+
+jest-runtime@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.0.1.tgz#b1d765fb03fb6d4043805af270676a693f504d57"
+>>>>>>> Upgrade dependencies
   dependencies:
     babel-core "^6.0.0"
     babel-plugin-istanbul "^4.1.6"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
     exit "^0.1.2"
+    fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.1.11"
+<<<<<<< HEAD
     jest-config "^23.0.0"
     jest-haste-map "^23.0.0"
     jest-message-util "^23.0.0"
@@ -4445,6 +5077,16 @@ jest-runtime@^23.0.0:
     jest-util "^23.0.0"
     jest-validate "^23.0.0"
     json-stable-stringify "^1.0.1"
+=======
+    jest-config "^23.0.1"
+    jest-haste-map "^23.0.1"
+    jest-message-util "^23.0.0"
+    jest-regex-util "^23.0.0"
+    jest-resolve "^23.0.1"
+    jest-snapshot "^23.0.1"
+    jest-util "^23.0.1"
+    jest-validate "^23.0.1"
+>>>>>>> Upgrade dependencies
     micromatch "^2.3.11"
     realpath-native "^1.0.0"
     slash "^1.0.0"
@@ -4452,6 +5094,7 @@ jest-runtime@^23.0.0:
     write-file-atomic "^2.1.0"
     yargs "^11.0.0"
 
+<<<<<<< HEAD
 jest-serializer@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.0.tgz#263411ac92e1e3dde243858642bb04e8a986e8ca"
@@ -4470,6 +5113,26 @@ jest-snapshot@^23.0.0:
 jest-util@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.0.0.tgz#86386800ffbe3fe17a06320e0cf9ca9b7868263b"
+=======
+jest-serializer@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
+
+jest-snapshot@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.0.1.tgz#6674fa19b9eb69a99cabecd415bddc42d6af3e7e"
+  dependencies:
+    chalk "^2.0.1"
+    jest-diff "^23.0.1"
+    jest-matcher-utils "^23.0.1"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    pretty-format "^23.0.1"
+
+jest-util@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.0.1.tgz#68ea5bd7edb177d3059f9797259f8e0dacce2f99"
+>>>>>>> Upgrade dependencies
   dependencies:
     callsites "^2.0.0"
     chalk "^2.0.1"
@@ -4479,13 +5142,20 @@ jest-util@^23.0.0:
     mkdirp "^0.5.1"
     source-map "^0.6.0"
 
+<<<<<<< HEAD
 jest-validate@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.0.0.tgz#f88bc897b6cc376979aff0262d1025df1302d520"
+=======
+jest-validate@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.0.1.tgz#cd9f01a89d26bb885f12a8667715e9c865a5754f"
+>>>>>>> Upgrade dependencies
   dependencies:
     chalk "^2.0.1"
     jest-get-type "^22.1.0"
     leven "^2.1.0"
+<<<<<<< HEAD
     pretty-format "^23.0.0"
 
 jest-worker@^23.0.0:
@@ -4500,6 +5170,30 @@ jest@^23.0.0:
   dependencies:
     import-local "^1.0.0"
     jest-cli "^23.0.0"
+=======
+    pretty-format "^23.0.1"
+
+jest-worker@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.0.1.tgz#9e649dd963ff4046026f91c4017f039a6aa4a7bc"
+  dependencies:
+    merge-stream "^1.0.1"
+
+jest@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-23.0.1.tgz#0d083290ee4112cecfb780df6ff81332ed373201"
+  dependencies:
+    import-local "^1.0.0"
+    jest-cli "^23.0.1"
+
+jpeg-js@0.1.2, jpeg-js@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.1.2.tgz#135b992c0575c985cfa0f494a3227ed238583ece"
+
+js-library-detector@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-4.3.1.tgz#6d34f55002813bc0a7543deef53faa4e2e79767b"
+>>>>>>> Upgrade dependencies
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -4694,6 +5388,16 @@ koa-send@^4.1.3:
 koa-static@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/koa-static/-/koa-static-4.0.3.tgz#5f93ad00fb1905db9ce46667c0e8bb7d22abfcd8"
+<<<<<<< HEAD
+=======
+  dependencies:
+    debug "^3.1.0"
+    koa-send "^4.1.3"
+
+koa-webpack-hot-middleware@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/koa-webpack-hot-middleware/-/koa-webpack-hot-middleware-1.0.3.tgz#df6aafbf2d77153101e37e6a4ae70235b466f8c0"
+>>>>>>> Upgrade dependencies
   dependencies:
     debug "^3.1.0"
     koa-send "^4.1.3"
@@ -4852,6 +5556,10 @@ makeerror@1.0.x:
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
+
+mamacro@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -5320,6 +6028,41 @@ nwmatcher@^1.4.3:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
 
+<<<<<<< HEAD
+=======
+nyc@^11.8.0:
+  version "11.8.0"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.8.0.tgz#1e8453b0644f8fea4d829b1a6636663157cd3b00"
+  dependencies:
+    archy "^1.0.0"
+    arrify "^1.0.1"
+    caching-transform "^1.0.0"
+    convert-source-map "^1.5.1"
+    debug-log "^1.0.1"
+    default-require-extensions "^1.0.0"
+    find-cache-dir "^0.1.1"
+    find-up "^2.1.0"
+    foreground-child "^1.5.3"
+    glob "^7.0.6"
+    istanbul-lib-coverage "^1.1.2"
+    istanbul-lib-hook "^1.1.0"
+    istanbul-lib-instrument "^1.10.0"
+    istanbul-lib-report "^1.1.3"
+    istanbul-lib-source-maps "^1.2.3"
+    istanbul-reports "^1.4.0"
+    md5-hex "^1.2.0"
+    merge-source-map "^1.1.0"
+    micromatch "^3.1.10"
+    mkdirp "^0.5.0"
+    resolve-from "^2.0.0"
+    rimraf "^2.6.2"
+    signal-exit "^3.0.1"
+    spawn-wrap "^1.4.2"
+    test-exclude "^4.2.0"
+    yargs "11.1.0"
+    yargs-parser "^8.0.0"
+
+>>>>>>> Upgrade dependencies
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
@@ -5725,6 +6468,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+<<<<<<< HEAD
 prettier@1.13.5:
   version "1.13.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.5.tgz#7ae2076998c8edce79d63834e9b7b09fead6bfd0"
@@ -5732,6 +6476,15 @@ prettier@1.13.5:
 pretty-format@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.0.0.tgz#b66dc584a0907b1969783c4c20e4d1180b18ac75"
+=======
+prettier@1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.2.tgz#412b87bc561cb11074d2877a33a38f78c2303cda"
+
+pretty-format@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.0.1.tgz#d61d065268e4c759083bccbca27a01ad7c7601f4"
+>>>>>>> Upgrade dependencies
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -5968,7 +6721,11 @@ react-dev-utils@^5.0.1:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
+<<<<<<< HEAD
 react-dom@^16.4.0:
+=======
+react-dom@16.4.0:
+>>>>>>> Upgrade dependencies
   version "16.4.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.0.tgz#099f067dd5827ce36a29eaf9a6cdc7cbf6216b1e"
   dependencies:
@@ -6021,13 +6778,23 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
+<<<<<<< HEAD
 react-test-renderer@^16.0.0-0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
+=======
+react-test-renderer@16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.0.tgz#0dbe0e24263e94e1830c7afb1f403707fad313a3"
+>>>>>>> Upgrade dependencies
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+<<<<<<< HEAD
+=======
+    react-is "^16.4.0"
+>>>>>>> Upgrade dependencies
 
 react-test-renderer@^16.4.0:
   version "16.4.0"
@@ -6038,7 +6805,11 @@ react-test-renderer@^16.4.0:
     prop-types "^15.6.0"
     react-is "^16.4.0"
 
+<<<<<<< HEAD
 react@^16.4.0:
+=======
+react@16.4.0:
+>>>>>>> Upgrade dependencies
   version "16.4.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.4.0.tgz#402c2db83335336fba1962c08b98c6272617d585"
   dependencies:
@@ -6180,6 +6951,27 @@ regexpu-core@^4.1.3:
 regexpu-core@^4.1.4:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.1.5.tgz#57fdfe1148f8a7a069086228515130cf1820ddd0"
+<<<<<<< HEAD
+=======
+  dependencies:
+    regenerate "^1.4.0"
+    regenerate-unicode-properties "^6.0.0"
+    regjsgen "^0.4.0"
+    regjsparser "^0.3.0"
+    unicode-match-property-ecmascript "^1.0.3"
+    unicode-match-property-value-ecmascript "^1.0.1"
+
+registry-auth-token@^3.0.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
+  dependencies:
+    rc "^1.1.6"
+    safe-buffer "^5.0.1"
+
+registry-url@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+>>>>>>> Upgrade dependencies
   dependencies:
     regenerate "^1.4.0"
     regenerate-unicode-properties "^6.0.0"
@@ -7073,7 +7865,24 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+<<<<<<< HEAD
 test-exclude@^4.2.1:
+=======
+temp@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
+  dependencies:
+    os-tmpdir "^1.0.0"
+    rimraf "~2.2.6"
+
+term-size@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
+  dependencies:
+    execa "^0.7.0"
+
+test-exclude@^4.2.0, test-exclude@^4.2.1:
+>>>>>>> Upgrade dependencies
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
   dependencies:
@@ -7445,6 +8254,7 @@ watchpack@^1.5.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
+<<<<<<< HEAD
 webassemblyjs@1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webassemblyjs/-/webassemblyjs-1.4.3.tgz#0591893efb8fbde74498251cbe4b2d83df9239cb"
@@ -7454,11 +8264,81 @@ webassemblyjs@1.4.3:
     "@webassemblyjs/wasm-parser" "1.4.3"
     "@webassemblyjs/wast-parser" "1.4.3"
     long "^3.2.0"
+=======
+wbuf@^1.1.0, wbuf@^1.7.2:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
+  dependencies:
+    minimalistic-assert "^1.0.0"
+>>>>>>> Upgrade dependencies
 
 webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
+<<<<<<< HEAD
+=======
+webpack-chunk-hash@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/webpack-chunk-hash/-/webpack-chunk-hash-0.6.0.tgz#eca36aff76e327d08a18a3e7990eb46e68376818"
+  dependencies:
+    "@types/webpack" "^3.0.0 || ^4.0.0"
+
+webpack-dev-middleware@3.1.3, webpack-dev-middleware@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.1.3.tgz#8b32aa43da9ae79368c1bf1183f2b6cf5e1f39ed"
+  dependencies:
+    loud-rejection "^1.6.0"
+    memory-fs "~0.4.1"
+    mime "^2.1.0"
+    path-is-absolute "^1.0.0"
+    range-parser "^1.0.3"
+    url-join "^4.0.0"
+    webpack-log "^1.0.1"
+
+webpack-dev-server@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.1.4.tgz#9a08d13c4addd1e3b6d8ace116e86715094ad5b4"
+  dependencies:
+    ansi-html "0.0.7"
+    array-includes "^3.0.3"
+    bonjour "^3.5.0"
+    chokidar "^2.0.0"
+    compression "^1.5.2"
+    connect-history-api-fallback "^1.3.0"
+    debug "^3.1.0"
+    del "^3.0.0"
+    express "^4.16.2"
+    html-entities "^1.2.0"
+    http-proxy-middleware "~0.18.0"
+    import-local "^1.0.0"
+    internal-ip "1.2.0"
+    ip "^1.1.5"
+    killable "^1.0.0"
+    loglevel "^1.4.1"
+    opn "^5.1.0"
+    portfinder "^1.0.9"
+    selfsigned "^1.9.1"
+    serve-index "^1.7.2"
+    sockjs "0.3.19"
+    sockjs-client "1.1.4"
+    spdy "^3.4.1"
+    strip-ansi "^3.0.0"
+    supports-color "^5.1.0"
+    webpack-dev-middleware "3.1.3"
+    webpack-log "^1.1.2"
+    yargs "11.0.0"
+
+webpack-hot-middleware@2.x:
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.21.2.tgz#2e2aa65563b8b32546b67e53b5a9667dcd80f327"
+  dependencies:
+    ansi-html "0.0.7"
+    html-entities "^1.2.0"
+    querystring "^0.2.0"
+    strip-ansi "^3.0.0"
+
+>>>>>>> Upgrade dependencies
 webpack-hot-middleware@^2.22.2:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.22.2.tgz#623b77ce591fcd4e1fb99f18167781443e50afac"
@@ -7475,6 +8355,7 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
+<<<<<<< HEAD
 webpack@^4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.9.0.tgz#a795fd0fad72205faa46bdca09ffaa36f4446262"
@@ -7482,6 +8363,16 @@ webpack@^4.9.0:
     "@webassemblyjs/ast" "1.4.3"
     "@webassemblyjs/wasm-edit" "1.4.3"
     "@webassemblyjs/wasm-parser" "1.4.3"
+=======
+webpack@^4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.10.1.tgz#74909fb9c32941b5c34d22c1f8782c9a033a52e7"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.8"
+    "@webassemblyjs/wasm-edit" "1.5.8"
+    "@webassemblyjs/wasm-opt" "1.5.8"
+    "@webassemblyjs/wasm-parser" "1.5.8"
+>>>>>>> Upgrade dependencies
     acorn "^5.0.0"
     acorn-dynamic-import "^3.0.0"
     ajv "^6.1.0"
@@ -7645,6 +8536,21 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
+<<<<<<< HEAD
+=======
+yargs-parser@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs-parser@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  dependencies:
+    camelcase "^4.1.0"
+
+>>>>>>> Upgrade dependencies
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
@@ -7668,6 +8574,38 @@ yargs@^11.0.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
+<<<<<<< HEAD
+=======
+yargs@11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
+
+yargs@3.32.0:
+  version "3.32.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
+  dependencies:
+    camelcase "^2.0.1"
+    cliui "^3.0.3"
+    decamelize "^1.1.1"
+    os-locale "^1.4.0"
+    string-width "^1.0.1"
+    window-size "^0.1.4"
+    y18n "^3.2.0"
+
+>>>>>>> Upgrade dependencies
 yargs@~3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"


### PR DESCRIPTION
This option allows apps to opt into aggressive tree shaking / import pruning by assuming all import statements are side effect free

This means:
- Unused specifiers of import statements can be tree shaken (provided the source module is comprised of simple re-export statements)
- Completely unused import statements (all specifiers are unused) can be pruned entirely

We may eventually want to turn on some form of behavior on by default. Also, our custom babel tree shaking babel plugin is redundant once dead branches in LogicalExpressions removed in Webpack itself.