### PR TITLE
Fix json importing

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -326,6 +326,7 @@ function getConfig({target, env, dir, watch, cover}) {
         {
           type: 'javascript/auto',
           test: /\.(json)/,
+          loader: 'json-loader',
         },
         fusionConfig.assumeNoImportSideEffects && {
           sideEffects: false,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "istanbul-api": "^1.3.1",
     "istanbul-lib-coverage": "^1.2.0",
     "jest": "^23.0.0",
+    "json-loader": "^0.5.7",
     "just-snake-case": "^1.0.0",
     "koa-mount": "^3.0.0",
     "koa-static": "^4.0.3",

--- a/test/cli/dev.js
+++ b/test/cli/dev.js
@@ -31,7 +31,7 @@ test('`fusion dev` works', async t => {
   t.end();
 });
 
-test('`fusion dev` works with assets', async t => {
+test.only('`fusion dev` works with assets', async t => {
   const dir = path.resolve(__dirname, '../fixtures/assets');
   const entryPath = path.resolve(
     dir,
@@ -64,6 +64,7 @@ test('`fusion dev` works with assets', async t => {
       await request(`http://localhost:${port}/json`),
       '/_static/20355efabaae9ed4d51fbc5a68eb4ce3.json'
     );
+    t.equal(await request(`http://localhost:${port}/json-import`), 'value');
     t.equal(
       await request(`http://localhost:${port}/hoisted`),
       expectedAssetPath

--- a/test/cli/dev.js
+++ b/test/cli/dev.js
@@ -31,7 +31,7 @@ test('`fusion dev` works', async t => {
   t.end();
 });
 
-test.only('`fusion dev` works with assets', async t => {
+test('`fusion dev` works with assets', async t => {
   const dir = path.resolve(__dirname, '../fixtures/assets');
   const entryPath = path.resolve(
     dir,
@@ -62,9 +62,12 @@ test.only('`fusion dev` works with assets', async t => {
     t.equal(await request(`http://localhost:${port}/filename`), 'src/main.js');
     t.equal(
       await request(`http://localhost:${port}/json`),
-      '/_static/20355efabaae9ed4d51fbc5a68eb4ce3.json'
+      '/_static/7526e1bdce8d3d115d6b4d6b79096e1c.json'
     );
-    t.equal(await request(`http://localhost:${port}/json-import`), 'value');
+    t.equal(
+      await request(`http://localhost:${port}/json-import`),
+      '{"key":"value"}'
+    );
     t.equal(
       await request(`http://localhost:${port}/hoisted`),
       expectedAssetPath

--- a/test/fixtures/assets/src/main.js
+++ b/test/fixtures/assets/src/main.js
@@ -1,5 +1,6 @@
 import App from 'fusion-core';
 import {assetUrl} from 'fusion-core';
+import * as jsonData from './static/test.json';
 
 const hoistedUrl = assetUrl('./static/test.css');
 
@@ -19,6 +20,8 @@ export default (async function() {
         ctx.body = hoistedUrl;
       } else if (ctx.url === '/json') {
         ctx.body = assetUrl('./static/test.json');
+      } else if (ctx.url === '/json-import') {
+        ctx.body = jsonData.key;
       }
       return next();
     });

--- a/test/fixtures/assets/src/main.js
+++ b/test/fixtures/assets/src/main.js
@@ -21,7 +21,7 @@ export default (async function() {
       } else if (ctx.url === '/json') {
         ctx.body = assetUrl('./static/test.json');
       } else if (ctx.url === '/json-import') {
-        ctx.body = jsonData.key;
+        ctx.body = JSON.stringify(jsonData);
       }
       return next();
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4596,6 +4596,10 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
+json-loader@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
+
 json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"


### PR DESCRIPTION
We need to explicitly use the json-loader, or importing json content will not work due to our loader config of overriding the type. It seems that the JSON in webpack 4 won't work, but the json-loader package will. I haven't investigated why.