### PR TITLE
Run user plugins in same order during test as during build

### DIFF
--- a/build/jest/jest-transformer.js
+++ b/build/jest/jest-transformer.js
@@ -33,8 +33,9 @@ if (!babelConfig.plugins) {
 babelConfig.plugins.push(require.resolve('babel-plugin-dynamic-import-node'));
 
 if (fusionConfig.babel && fusionConfig.babel.plugins) {
-  babelConfig.plugins = babelConfig.plugins.concat(
-    ...fusionConfig.babel.plugins
+  // Run user-defined plugins first
+  babelConfig.plugins = fusionConfig.babel.plugins.concat(
+    ...babelConfig.plugins
   );
 }
 


### PR DESCRIPTION
When building user defined babel plugins run first (defined in build/compiler.js) but when testing they run last. This creates inconsistent behaviors and hard to debug issues.