### PR TITLE
Do not resolve symlinks during build

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -356,6 +356,7 @@ function getConfig({target, env, dir, watch, cover}) {
         }),
     ].filter(Boolean),
     resolve: {
+      symlinks: false,
       aliasFields: [
         (target === 'web' || target === 'webworker') && 'browser',
         evergreen && 'es2015',


### PR DESCRIPTION
Tools such as `npm link` or `yarn link` use symlinks which when resolved break the build. Disabling resolve.symlinks will ensure they work correctly. (Doc: https://webpack.js.org/configuration/resolve/#resolve-symlinks)