### PR TITLE
Fix module reloading

### DIFF
--- a/build/jest/jest-transformer.js
+++ b/build/jest/jest-transformer.js
@@ -10,9 +10,9 @@
 
 // Clear require cache before each run to reset file exports between environment runs.
 // Currently the transformer seems like the most robust place to clear cache.
-Object.keys(require.cache).forEach(key => {
-  delete require.cache[key];
-});
+const clearModule = require('clear-module');
+
+clearModule.all();
 
 const loadFusionRC = require('../load-fusionrc.js');
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bundle-analyzer": "^0.0.6",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "chalk": "^2.4.1",
+    "clear-module": "^3.0.0",
     "compression-webpack-plugin": "^1.1.11",
     "core-js": "^2.5.7",
     "enzyme-adapter-react-16": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1731,11 +1731,23 @@ call-me-maybe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
 
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  dependencies:
+    callsites "^2.0.0"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
   dependencies:
     callsites "^0.2.0"
+
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  dependencies:
+    caller-callsite "^2.0.0"
 
 callsites@^0.2.0:
   version "0.2.0"
@@ -1870,6 +1882,13 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+clear-module@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/clear-module/-/clear-module-3.0.0.tgz#e5ea80c0955fc087d4402b1b5f94fc8385927280"
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^4.0.0"
 
 cli-cursor@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Motivation

Fusion tests can be run as "server-side" or "client-side" depending on a file naming conventions. Due to this distinction and the fact that we use Jest, we need to clear the Node require cache between runs, otherwise saturating a core would cause tests to fail (see [https://github.com/fusionjs/fusion-cli/pull/328](https://github.com/fusionjs/fusion-cli/pull/328) for more information).

We clear cache from a jest transformer file, but we used a naive heuristic that simply deleted the modules from cache.

As it turns out, the simplistic heuristic can still cause module loading errors in some circumstances (notably during debug, where tests are run with the --runInBand flag).

Changing to a more robust module clearing library seems to fix this issue