### PR TITLE
Do not log babel notice for assumeNoImportSideEffects

### DIFF
--- a/build/load-fusionrc.js
+++ b/build/load-fusionrc.js
@@ -26,7 +26,7 @@ module.exports = function validateConfig(
     if (!isValid(config)) {
       throw new Error('.fusionrc.js is invalid');
     }
-    if (!loggedNotice) {
+    if (!loggedNotice && config.babel) {
       console.log(chalk.dim('Using custom Babel config from .fusionrc.js'));
       console.warn(
         chalk.yellow(


### PR DESCRIPTION
Right now we log a babel warning whenever using `assumeNoImportSideEffects` within a .fusionjs.rc file. This warning can be confusing when not using a custom babel configuration, and only using assumeNoImportSideEffects.