### PR TITLE
Fix i18n discovery on dev restart

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -473,7 +473,13 @@ function getConfig({target, env, dir, watch, cover}) {
             chunkModuleManifest.set(chunkMap);
           },
         }),
-      target === 'web' && new I18nDiscoveryPlugin(),
+      target === 'web' &&
+        new I18nDiscoveryPlugin({
+          cachePath: path.join(
+            dir,
+            'node_modules/.fusion_babel_cache/i18n-manifest.json'
+          ),
+        }),
       // case-insensitive paths can cause problems
       new CaseSensitivePathsPlugin(),
       target === 'web' && new AssetsManifestPlugin(),

--- a/build/i18n-discovery-plugin.js
+++ b/build/i18n-discovery-plugin.js
@@ -8,15 +8,42 @@
 
 /* eslint-env node */
 
+const fs = require('fs');
+
 const manifest = require('./i18n-manifest.js');
 const emitter = require('./i18n-manifest-emitter.js');
 
 class I18nDiscoveryPlugin {
+  /*:: cachePath: string; */
+
+  constructor(opts /*: {cachePath: string} */) {
+    this.cachePath = opts.cachePath;
+    // On initial build, hydrate translations from previous build
+    // if valid cache exists
+    if (fs.existsSync(this.cachePath)) {
+      try {
+        let cached = JSON.parse(fs.readFileSync(this.cachePath, 'utf8'));
+        hydrate(cached);
+      } catch (e) {
+        // Do nothing
+      }
+    }
+  }
   apply(compiler /*: any */) {
     compiler.hooks.done.tap('I18nDiscoveryPlugin', () => {
+      try {
+        fs.writeFileSync(this.cachePath, serialize());
+      } catch (e) {
+        // Do nothing
+      }
       emitter.set(manifest);
     });
     compiler.hooks.invalid.tap('I18nDiscoveryPlugin', filename => {
+      try {
+        fs.unlinkSync(this.cachePath);
+      } catch (e) {
+        // Do nothing
+      }
       emitter.invalidate();
       manifest.delete(filename);
     });
@@ -24,3 +51,18 @@ class I18nDiscoveryPlugin {
 }
 
 module.exports = I18nDiscoveryPlugin;
+
+function serialize() {
+  const json = {};
+  for (let [file, translations] of manifest.entries()) {
+    json[file] = Array.from(translations);
+  }
+  return JSON.stringify(json);
+}
+
+function hydrate(parsed) {
+  Object.keys(parsed).forEach(file => {
+    const translations = new Set([parsed[file]]);
+    manifest.set(file, translations);
+  });
+}

--- a/test/cli/dev.js
+++ b/test/cli/dev.js
@@ -371,7 +371,12 @@ test('`fusion dev` app with split translations integration', async t => {
 test('`fusion dev` app with split translations integration (cached)', async t => {
   const dir = path.resolve(__dirname, '../fixtures/split-translations');
 
-  const {proc, port} = await dev(`--dir=${dir}`, {cwd: dir});
+  // Startup first time
+  let {proc, port} = await dev(`--dir=${dir}`, {cwd: dir});
+  proc.kill();
+
+  // Restart
+  ({proc, port} = await dev(`--dir=${dir}`, {cwd: dir}));
   const browser = await puppeteer.launch({
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
   });

--- a/test/cli/dev.js
+++ b/test/cli/dev.js
@@ -367,3 +367,34 @@ test('`fusion dev` app with split translations integration', async t => {
 
   t.end();
 });
+
+test('`fusion dev` app with split translations integration (cached)', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/split-translations');
+
+  const {proc, port} = await dev(`--dir=${dir}`, {cwd: dir});
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const page = await browser.newPage();
+  await page.goto(`http://localhost:${port}/`, {waitUntil: 'load'});
+  const content = await page.content();
+  t.ok(
+    content.includes('<span>__MAIN_TRANSLATED__</span>'),
+    'app content contains translated main chunk'
+  );
+
+  await Promise.all([
+    page.click('#split1-link'),
+    page.waitForSelector('#split1-translation'),
+  ]);
+  const content2 = await page.content();
+  t.ok(
+    content2.includes('__SPLIT1_TRANSLATED__'),
+    'renders first  split translation'
+  );
+
+  await browser.close();
+  proc.kill();
+
+  t.end();
+});


### PR DESCRIPTION
We currently have a persistent Babel cache, but translations discovery plugin relies on Babel. Thus in watch mode, when restarting the server, no translations are found because of the cache. This PR sets up a persistent cache that is hydrated on restart to resolve this.

Ideally this isn't necessary, but it is given the current setup with `babel-loader`/`webpack` and Babel caching. Fortunately, this code won't be needed once https://github.com/fusionjs/fusion-cli/issues/426 is implemented because the compilation pipeline will be rather different.