### PR TITLE
Fix issue with dev process crashing

### DIFF
--- a/build/dev-runtime.js
+++ b/build/dev-runtime.js
@@ -62,6 +62,7 @@ type DevRuntimeType = {
   run: () => any,
   start: () => any,
   stop: () => any,
+  invalidate: () => void 
 };
 */
 
@@ -159,6 +160,8 @@ module.exports.DevelopmentRuntime = function(
       });
     });
   };
+
+  this.invalidate = () => lifecycle.stop();
 
   function killProc() {
     if (state.proc) {

--- a/commands/dev.js
+++ b/commands/dev.js
@@ -74,9 +74,7 @@ exports.run = async function(
 
   // Rerun for each recompile
   compiler.on('done', runAll);
-  compiler.on('invalid', () => {
-    devRuntime.run();
-  });
+  compiler.on('invalid', () => devRuntime.invalidate());
 
   return {
     compiler,

--- a/test/index.js
+++ b/test/index.js
@@ -28,3 +28,7 @@ require('../build/babel-plugins/babel-plugin-sync-chunk-ids/test');
 require('../build/babel-plugins/babel-plugin-sync-chunk-paths/test');
 require('../build/babel-plugins/babel-plugin-utils/test');
 require('../build/babel-plugins/babel-plugin-transform-tree-shake/test');
+
+process.on('unhandledRejection', e => {
+  throw e;
+});


### PR DESCRIPTION
Previously we were trying to start up the server immediately when the compilation was invalid. Instead, we should inform the dev runtime that the build is in progress. This fixes a bug where the second error after a crashed server would cause the dev process to crash.

Fixes #441 