### PR TITLE
Display application running URL on yarn dev

### DIFF
--- a/commands/dev.js
+++ b/commands/dev.js
@@ -60,6 +60,9 @@ exports.run = async function(
         // $FlowFixMe
         testRuntime ? testRuntime.run() : Promise.resolve(),
       ]);
+      if (!open) {
+        logger.info(`Application is running on http://localhost:${port}`);
+      }
     } catch (e) {} // eslint-disable-line
   };
 


### PR DESCRIPTION
Will log info of URL where the application is running only if `--open=false` command is provided,
mostly it helps us to not guess the PORT where the server is running.