### PR TITLE
Prevent tree-shaking of polyfills

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -235,7 +235,7 @@ function getConfig({target, env, dir, watch, cover}) {
           exclude: [
             // Blacklist mapbox-gl package because of issues with babel-loader and its AMD bundle
             /node_modules\/mapbox-gl/,
-            // Blacklist react packages for performance
+            // Blacklist known ES5 packages for build performance
             /node_modules\/react-dom/,
             /node_modules\/react/,
             /node_modules\/core-js/,

--- a/build/compiler.js
+++ b/build/compiler.js
@@ -238,6 +238,7 @@ function getConfig({target, env, dir, watch, cover}) {
             // Blacklist react packages for performance
             /node_modules\/react-dom/,
             /node_modules\/react/,
+            /node_modules\/core-js/,
           ],
           use: [
             {

--- a/entries/client-entry.js
+++ b/entries/client-entry.js
@@ -9,8 +9,10 @@
 /* eslint-env browser */
 /* global module */
 
-import 'core-js/es6';
-import 'core-js/es7';
+// Require is used to opt out of webpack tree-shaking of ununsed imports
+// See: https://github.com/webpack/webpack/issues/6571
+require('core-js/es6'); // eslint-disable-line
+require('core-js/es7'); // eslint-disable-line
 
 /*
 Webpack has a configuration option called `publicPath`, which determines the


### PR DESCRIPTION
If `assumeNoImportSideEffects` is set to `true`, then imports for side effects will be tree-shaken (per https://github.com/webpack/webpack/issues/6571 effectful imports are not considered side effect free by webpack).

Because the API of core-js relies on import side effects (rather than some actual polyfill method) this means polyfills are erroneously never included.

This PR avoids this behavior by changing the polyfill imports to use `require` instead. 