### PR TITLE
Revert require.cache busting

### DIFF
--- a/build/jest/base-jest-config.js
+++ b/build/jest/base-jest-config.js
@@ -33,7 +33,6 @@ function getReactSetup() {
 const reactSetup = getReactSetup();
 
 module.exports = {
-  cache: false,
   coverageDirectory: `${process.cwd()}/coverage`,
   coverageReporters: ['json'],
   rootDir: process.cwd(),

--- a/build/jest/jest-config.js
+++ b/build/jest/jest-config.js
@@ -26,6 +26,7 @@ if (projects.length > 1) {
   // $FlowFixMe
   config.projects = projects.map(project => {
     return {
+      // $FlowFixMe
       ...require(`./${project === 'jsdom' ? 'jsdom' : 'node'}/jest.config.js`),
     };
   });

--- a/build/jest/jest-config.js
+++ b/build/jest/jest-config.js
@@ -14,7 +14,6 @@ const baseJestConfig = require('./base-jest-config.js');
 const projects = process.env.JEST_ENV.split(',');
 
 let config = {
-  cache: false,
   coverageDirectory: `${process.cwd()}/coverage`,
   // collectCoverageFrom doesn't work from project config,
   // must be set at top-level
@@ -25,7 +24,11 @@ let config = {
 // Use projects if we have more than one environment.
 if (projects.length > 1) {
   // $FlowFixMe
-  config.projects = projects.map(project => `<rootDir>/${project}`);
+  config.projects = projects.map(project => {
+    return {
+      ...require(`./${project === 'jsdom' ? 'jsdom' : 'node'}/jest.config.js`),
+    };
+  });
 } else {
   config = {
     // $FlowFixMe

--- a/build/jest/jest-transformer.js
+++ b/build/jest/jest-transformer.js
@@ -8,12 +8,6 @@
 
 /* eslint-env node */
 
-// Clear require cache before each run to reset file exports between environment runs.
-// Currently the transformer seems like the most robust place to clear cache.
-const clearModule = require('clear-module');
-
-clearModule.all();
-
 const loadFusionRC = require('../load-fusionrc.js');
 
 const babelConfig = require('../babel-preset.js')(null, {


### PR DESCRIPTION
- [clearing require.cache](https://github.com/fusionjs/fusion-cli/blob/fa1ed5fac5624eefdb8d5b9103ee4436885cc386/build/jest/jest-transformer.js#L15) was a workaround to prevent test failures when running server and browser tests concurrently. However, this workaround causes sporadic `Module did not self-register` errors from binary dependencies, which themselves cannot be worked around.
- original issue was isolated in https://github.com/facebook/jest/issues/6887
- new workaround: use `fusion test --env node && fusion test --env jsdom` instead of `fusion test` if you have server and browser tests running concurrently
- downsides: coverage for node and jsdom tests are not consolidated

Next steps:

- tell people to use the new workaround
- wait for upstream fix in Jest