### PR TITLE
Release v1.9.1-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fusion-cli",
-  "version": "1.9.1-0",
+  "version": "1.9.1-1",
   "description": "CLI",
   "repository": "fusionjs/fusion-cli",
   "bin": {


### PR DESCRIPTION
For some reason the 1.9.1-0 release is missing, and we're also missing the GitHub release. Trying a manual release for now.