### PR TITLE
Add no-cache flag when --debug is set

### DIFF
--- a/build/test-runtime.js
+++ b/build/test-runtime.js
@@ -39,6 +39,8 @@ module.exports.TestAppRuntime = function(
           '--inspect-brk',
           require.resolve('jest/bin/jest.js'),
           '--runInBand',
+          // --no-cache is required to allow debugging from vscode
+          '--no-cache',
         ];
       }
 


### PR DESCRIPTION
This is required for VSCode users to be able to debug from within VSCode.

See: https://github.com/facebook/jest/issues/6683#issuecomment-417515963