### PR TITLE
Support a whitelist of Jest CLI arguments

### DIFF
--- a/build/jest/cli-options.js
+++ b/build/jest/cli-options.js
@@ -1,0 +1,39 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-env node */
+
+exports.allowedJestOptions = [
+  'changedFilesWithAncestor',
+  'changedSince',
+  'ci',
+  'clearCache',
+  'colors',
+  'coverage',
+  'detectOpenHandles',
+  'errorOnDeprecated',
+  'expand',
+  'findRelatedTests',
+  'json',
+  'lastCommit',
+  'listTests',
+  'logHeapUsage',
+  'noStackTrace',
+  'notify',
+  'onlyChanged',
+  'passWithNoTests',
+  'reporters',
+  'showConfig',
+  'silent',
+  'testLocationInResults',
+  'useStderr',
+  'version',
+  'watch',
+  'watchAll',
+  'watchman',
+];

--- a/build/test-runtime.js
+++ b/build/test-runtime.js
@@ -17,14 +17,13 @@ const convertCoverage = require('./convert-coverage');
 module.exports.TestAppRuntime = function(
   {
     dir = '.',
-    watch = false,
     debug = false,
     match,
     env,
     testFolder,
     updateSnapshot,
-    coverage,
     configPath,
+    jestArgs = {},
   } /*: any */
 ) {
   const state = {procs: []};
@@ -45,30 +44,23 @@ module.exports.TestAppRuntime = function(
       }
 
       args = args.concat(['--config', configPath]);
-
-      if (watch) {
-        args.push('--watch');
-      }
-
-      if (coverage) {
-        args.push('--coverage');
-      }
+      Object.keys(jestArgs).forEach(arg => {
+        const value = jestArgs[arg];
+        if (value && typeof value === 'boolean') {
+          args.push(`--${arg}`);
+        }
+      });
 
       if (match && match.length > 0) {
         args.push(match);
       }
 
-      if (updateSnapshot) {
-        args.push('--updateSnapshot');
-      }
-
       args.push('--verbose');
-
       return args;
     };
 
     const setup = () => {
-      if (!coverage) {
+      if (!jestArgs.coverage) {
         return Promise.resolve();
       }
 
@@ -111,7 +103,7 @@ module.exports.TestAppRuntime = function(
     };
 
     const finish = () => {
-      if (!coverage) {
+      if (!jestArgs.coverage) {
         return Promise.resolve();
       }
       return convertCoverage(rootDir);

--- a/commands/index.js
+++ b/commands/index.js
@@ -1,5 +1,18 @@
 // @flow
 /* eslint-env node */
+
+const {allowedJestOptions} = require('../build/jest/cli-options');
+
+const jestOptionsDescriptions = {};
+allowedJestOptions.forEach(arg => {
+  jestOptionsDescriptions[arg] = {
+    type: 'boolean',
+    describe:
+      'Jest CLI argument. See: https://jestjs.io/docs/en/cli.html#' +
+      arg.toLowerCase(),
+  };
+});
+
 module.exports = {
   build: {
     descr: 'Build your app',
@@ -108,17 +121,12 @@ module.exports = {
       dir: {
         type: 'string',
         default: '.',
-        describe: 'Root path for the application relative to CLI CWD',
+        describe: 'Root path for the application relative to CLI CWD.',
       },
       debug: {
         type: 'boolean',
         default: false,
-        describe: 'Debug tests',
-      },
-      watch: {
-        type: 'boolean',
-        default: false,
-        describe: 'Automatically re-run tests on file changes',
+        describe: 'Debug tests using --inspect-brk and --runInBand.',
       },
       match: {
         type: 'string',
@@ -136,21 +144,12 @@ module.exports = {
         default: '__tests__',
         describe: 'Which folder to look for tests in.',
       },
-      updateSnapshot: {
-        type: 'boolean',
-        default: false,
-        describe: 'Updates snapshots',
-      },
-      coverage: {
-        type: 'boolean',
-        default: false,
-        describe: 'Runs test coverage',
-      },
       configPath: {
         type: 'string',
         default: './node_modules/fusion-cli/build/jest/jest-config.js',
-        describe: 'Path to the jest configuration',
+        describe: 'Path to the jest configuration, used for testing.',
       },
+      ...jestOptionsDescriptions,
     },
   },
 };

--- a/commands/test.js
+++ b/commands/test.js
@@ -8,6 +8,7 @@
 
 /* eslint-env node */
 
+const {allowedJestOptions} = require('../build/jest/cli-options');
 const {TestAppRuntime} = require('../build/test-runtime');
 
 exports.run = async function(
@@ -30,36 +31,7 @@ exports.run = async function(
   const jestArgs /*: any */ = {
     updateSnapshot: updateSnapshot || u || false,
   };
-  const whitelistedJestOptions = [
-    'changedFilesWithAncestor',
-    'changedSince',
-    'ci',
-    'clearCache',
-    'colors',
-    'coverage',
-    'detectOpenHandles',
-    'errorOnDeprecated',
-    'expand',
-    'findRelatedTests',
-    'json',
-    'lastCommit',
-    'listTests',
-    'logHeapUsage',
-    'noStackTrace',
-    'notify',
-    'onlyChanged',
-    'passWithNoTests',
-    'reporters',
-    'showConfig',
-    'silent',
-    'testLocationInResults',
-    'useStderr',
-    'version',
-    'watch',
-    'watchAll',
-    'watchman',
-  ];
-  whitelistedJestOptions.forEach(arg => {
+  allowedJestOptions.forEach(arg => {
     if (rest[arg]) {
       jestArgs[arg] = rest[arg];
     }

--- a/commands/test.js
+++ b/commands/test.js
@@ -13,30 +13,66 @@ const {TestAppRuntime} = require('../build/test-runtime');
 exports.run = async function(
   {
     dir = '.',
-    watch,
     debug,
     match,
     env,
     testFolder,
-    updateSnapshot,
-    coverage,
     configPath,
     // Allow snapshots to be updated using `-u` as well as --updateSnapshot.
     // We don't document this argument, but since jest output automatically
     // suggests this as a valid argument, we support it in case it's used.
     u,
+    updateSnapshot,
+    // Arguments which are passed through into jest
+    ...rest
   } /*: any */
 ) {
+  const jestArgs /*: any */ = {
+    updateSnapshot: updateSnapshot || u || false,
+  };
+  const whitelistedJestOptions = [
+    'changedFilesWithAncestor',
+    'changedSince',
+    'ci',
+    'clearCache',
+    'colors',
+    'coverage',
+    'detectOpenHandles',
+    'errorOnDeprecated',
+    'expand',
+    'findRelatedTests',
+    'json',
+    'lastCommit',
+    'listTests',
+    'logHeapUsage',
+    'noStackTrace',
+    'notify',
+    'onlyChanged',
+    'passWithNoTests',
+    'reporters',
+    'showConfig',
+    'silent',
+    'testLocationInResults',
+    'useStderr',
+    'version',
+    'watch',
+    'watchAll',
+    'watchman',
+  ];
+  whitelistedJestOptions.forEach(arg => {
+    if (rest[arg]) {
+      jestArgs[arg] = rest[arg];
+    }
+  });
+
   const testRuntime = new TestAppRuntime({
     dir,
-    watch,
     debug,
     match,
     env,
     testFolder,
-    updateSnapshot: updateSnapshot || u,
-    coverage,
     configPath,
+    jestArgs,
   });
 
   // $FlowFixMe


### PR DESCRIPTION
Adds a whitelist of supported Jest CLI arguments which seem reasonable and useful. This does not add arguments which have potential to change the convention of test naming, coverage collection, or environment.

Sade output looks like:
![image](https://user-images.githubusercontent.com/122602/45055649-4617d880-b045-11e8-899d-8771b48810f1.png)

Fixes #500