### PR TITLE
Add @babel/plugin-transform-flow-strip-types in favor of @babel/preset-flow

### DIFF
--- a/build/babel-plugins/babel-plugin-utils/test/index.js
+++ b/build/babel-plugins/babel-plugin-utils/test/index.js
@@ -40,7 +40,9 @@ test('with flow types', t => {
     import type {footype} from 'bar';
     let baz: string = foo();
   `,
-    {plugins: [plugin], presets: [require('@babel/preset-flow')]}
+    {
+      plugins: [require('@babel/plugin-transform-flow-strip-types'), plugin],
+    }
   );
 });
 

--- a/build/get-babel-config.js
+++ b/build/get-babel-config.js
@@ -63,6 +63,7 @@ module.exports = function getBabelConfig(opts /*: BabelConfigOpts */) {
         development: dev,
       },
     ]);
+    config.plugins.unshift(require('@babel/plugin-transform-flow-strip-types'));
     config.presets.push(require('@babel/preset-flow'));
     if (fusionTransforms) {
       config.presets.push([fusionPreset, {runtime, assumeNoImportSideEffects}]);

--- a/build/get-babel-config.js
+++ b/build/get-babel-config.js
@@ -64,7 +64,6 @@ module.exports = function getBabelConfig(opts /*: BabelConfigOpts */) {
       },
     ]);
     config.plugins.unshift(require('@babel/plugin-transform-flow-strip-types'));
-    config.presets.push(require('@babel/preset-flow'));
     if (fusionTransforms) {
       config.presets.push([fusionPreset, {runtime, assumeNoImportSideEffects}]);
     }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "7.0.0",
     "@babel/plugin-syntax-dynamic-import": "7.0.0",
+    "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/preset-env": "7.0.0",
     "@babel/preset-flow": "7.0.0",
     "@babel/preset-react": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@babel/plugin-syntax-dynamic-import": "7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/preset-env": "7.0.0",
-    "@babel/preset-flow": "7.0.0",
     "@babel/preset-react": "7.0.0",
     "@gfx/zopfli": "^1.0.8",
     "babel-core": "^7.0.0-bridge.0",
@@ -64,7 +63,6 @@
     "winston": "^3.0.0"
   },
   "devDependencies": {
-    "@babel/preset-flow": "7.0.0",
     "babel-eslint": "9.0.0",
     "chrome-remote-interface": "^0.26.1",
     "enzyme": "3.5.0",

--- a/test/cli/test.js
+++ b/test/cli/test.js
@@ -228,6 +228,16 @@ test('`fusion test` coverage', async t => {
   t.end();
 });
 
+test('`fusion test` class properties', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
+  const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --match=class-props`;
+
+  const cmd = `require('${runnerPath}').run('node ${runnerPath} ${args}')`;
+  const response = await exec(`node -e "${cmd}"`);
+  t.equal(countTests(response.stderr), 2, 'ran 2 tests');
+  t.end();
+});
+
 test('`fusion test` cobertura coverage reports', async t => {
   const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
   const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --coverage --match=passes`;

--- a/test/fixtures/test-jest-app/src/__tests__/class-props.js
+++ b/test/fixtures/test-jest-app/src/__tests__/class-props.js
@@ -1,0 +1,13 @@
+// @flow
+import {test} from 'fusion-test-utils';
+
+import classPropFixture from '../class-props';
+
+test('Class properties work /w flow annotation', async assert => {
+  const result = new classPropFixture();
+  assert.equal(
+    result.classProp(),
+    true,
+    'class props work and evaluates to true'
+  );
+});

--- a/test/fixtures/test-jest-app/src/class-props.js
+++ b/test/fixtures/test-jest-app/src/class-props.js
@@ -1,0 +1,18 @@
+// @flow
+
+import React, {Component} from 'react';
+
+export default class ClassPropFixture {
+  // The following flow annotation is required in order to reproduce the failing test case (#505)
+  boundMethod: Function;
+
+  constructor() {
+    this.boundMethod = this.boundMethod.bind(this);
+  }
+
+  boundMethod(): void {}
+
+  classProp = () => {
+    return true;
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,13 +613,6 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
-"@babel/preset-flow@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.0.0.tgz#afd764835d9535ec63d8c7d4caf1c06457263da2"
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
-
 "@babel/preset-react@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.0.0.tgz#e86b4b3d99433c7b3e9e91747e2653958bc6b3c0"


### PR DESCRIPTION
* Installs and uses `@babel/plugin-transform-flow-strip-types`.
* Introduces a test case for a failure after upgrading to fusion-cli@1.10.0.

Note: We were including `@babel/preset-flow` inside of our `get-babel-config.js` file, but it seems to not actually work. It seems that this is due to some other plugins running before the preset, possibly `@babel/plugin-proposal-class-properties`. We have to unshift the plugin to strip flow types first. This means that we can remove the `@babel/preset-flow` plugin.

This bug was introduced from https://github.com/fusionjs/fusion-cli/pull/486