### PR TITLE
Fix missing translations in dev after rebuild

### DIFF
--- a/build/plugins/i18n-discovery-plugin.js
+++ b/build/plugins/i18n-discovery-plugin.js
@@ -35,7 +35,7 @@ class I18nDiscoveryPlugin {
     });
     compiler.hooks.invalid.tap(name, filename => {
       this.manifest.reset();
-      this.discoveryState = new Map();
+      this.discoveryState.delete(filename);
     });
   }
 }

--- a/test/cli/dev.js
+++ b/test/cli/dev.js
@@ -400,6 +400,18 @@ test('`fusion dev` app with split translations integration', async t => {
     'renders second, hot split translation'
   );
 
+  await page.goto(`http://localhost:${port}/`, {waitUntil: 'load'});
+
+  await Promise.all([
+    page.click('#split1-link'),
+    page.waitForSelector('#split1-translation'),
+  ]);
+  const content4 = await page.content();
+  t.ok(
+    content4.includes('__SPLIT1_TRANSLATED__'),
+    'renders translation from unmodified file after rebuild'
+  );
+
   await browser.close();
   proc.kill();
 


### PR DESCRIPTION
All translations were being erroneously evicted on invalidation. Instead, only translations from modified files should be evicted (which will be re-analyzed later).

Our tests failed to cover this case because only translations from the file being modified were checked. This PR adds a regression test to check the rendered translation within an unmodified file after a rebuild.