### PR TITLE
Fix polyfilling with sideEffectFree option and add regression test

### DIFF
--- a/entries/client-entry.js
+++ b/entries/client-entry.js
@@ -9,10 +9,9 @@
 /* eslint-env browser */
 /* global module */
 
-// Require is used to opt out of webpack tree-shaking of ununsed imports
+// Require is used and assigned to an identifier to opt out of webpack tree-shaking of ununsed imports
 // See: https://github.com/webpack/webpack/issues/6571
-require("core-js"); // eslint-disable-line
-
+let some_identifier = require('core-js'); // eslint-disable-line
 /*
 Webpack has a configuration option called `publicPath`, which determines the
 base path for all assets within an application
@@ -34,12 +33,12 @@ into `__webpack_require__.p = ...` and uses it for HMR manifest requests
 
 /* eslint-disable */
 // $FlowFixMe
-__webpack_public_path__ = window.__WEBPACK_PUBLIC_PATH__ + "/";
+__webpack_public_path__ = window.__WEBPACK_PUBLIC_PATH__ + '/';
 /* eslint-enable */
 
 function reload() {
   // $FlowFixMe
-  const main = require("__FRAMEWORK_SHARED_ENTRY__"); // eslint-disable-line
+  const main = require('__FRAMEWORK_SHARED_ENTRY__'); // eslint-disable-line
   const initialize = main.default || main;
   Promise.resolve(initialize()).then(app => {
     app.callback().call();

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -539,6 +539,29 @@ test('`fusion build` tree shaking unused imports in dev w/ assumeNoImportSideEff
   t.end();
 });
 
+test('`fusion build` polyfills with assumeNoImportSideEffects: true', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/tree-shaking-unused');
+
+  var env = Object.create(process.env);
+  env.NODE_ENV = 'production';
+
+  await cmd(`build --dir=${dir} --production`, {env});
+
+  const distFolder = path.resolve(dir, '.fusion/dist/production/client');
+  const clientFiles = await readdir(distFolder);
+
+  const hasCoreJS = clientFiles
+    .filter(file => path.extname(file) === '.js')
+    .map(file => path.join(distFolder, file))
+    .some(file => {
+      return fs.readFileSync(file, 'utf-8').includes('__core-js_shared__');
+    });
+
+  t.ok(hasCoreJS, 'some client bundle JS includes core-js');
+
+  t.end();
+});
+
 test('`fusion build` tree shaking', async t => {
   const dir = path.resolve(__dirname, '../fixtures/tree-shaking');
   await cmd(`build --dir=${dir} --production=true`);


### PR DESCRIPTION
Side effect free require pruning was added to webpack so the existing CommonJS workaround stopped working.

This PR adds a regression test to prevent future breakages