### PR TITLE
Add experimentalCompile flag

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -84,6 +84,47 @@ function getConfig({target, env, dir, watch, state}) {
     web: clientEntry,
   }[target];
 
+  const babelConfig = fusionConfig.experimentalCompile
+    ? getBabelConfig({
+        dev: env === 'development',
+        jsx: {pragma},
+        fusionTransforms: true,
+        assumeNoImportSideEffects: fusionConfig.assumeNoImportSideEffects,
+        runtime: target === 'node' ? 'node-bundled' : 'browser-legacy',
+        specOnly: false,
+        plugins:
+          fusionConfig.babel && fusionConfig.babel.plugins
+            ? fusionConfig.babel.plugins
+            : [],
+        presets:
+          fusionConfig.babel && fusionConfig.babel.presets
+            ? fusionConfig.babel.presets
+            : [],
+      })
+    : getBabelConfig({
+        runtime: target === 'node' ? 'node-bundled' : 'browser-legacy',
+        specOnly: true,
+        plugins:
+          fusionConfig.babel && fusionConfig.babel.plugins
+            ? fusionConfig.babel.plugins
+            : [],
+        presets:
+          fusionConfig.babel && fusionConfig.babel.presets
+            ? fusionConfig.babel.presets
+            : [],
+      });
+
+  const babelOverrides = fusionConfig.experimentalCompile
+    ? {}
+    : getBabelConfig({
+        dev: env === 'development',
+        jsx: {pragma},
+        fusionTransforms: true,
+        assumeNoImportSideEffects: fusionConfig.assumeNoImportSideEffects,
+        runtime: target === 'node' ? 'node-bundled' : 'browser-legacy',
+        specOnly: false,
+      });
+
   const whitelist = ['fusion-cli/entries'];
 
   // NODE_ENV should be built as 'production' for everything except 'development'
@@ -203,19 +244,7 @@ function getConfig({target, env, dir, watch, state}) {
             {
               loader: babelLoader.path,
               options: {
-                ...getBabelConfig({
-                  runtime:
-                    target === 'node' ? 'node-bundled' : 'browser-legacy',
-                  specOnly: true,
-                  plugins:
-                    fusionConfig.babel && fusionConfig.babel.plugins
-                      ? fusionConfig.babel.plugins
-                      : [],
-                  presets:
-                    fusionConfig.babel && fusionConfig.babel.presets
-                      ? fusionConfig.babel.presets
-                      : [],
-                }),
+                ...babelConfig,
                 /**
                  * Fusion-specific transforms (not applied to node_modules)
                  */
@@ -228,16 +257,7 @@ function getConfig({target, env, dir, watch, state}) {
                       entry,
                       /fusion-cli\/entries/,
                     ],
-                    ...getBabelConfig({
-                      dev: env === 'development',
-                      jsx: {pragma},
-                      fusionTransforms: true,
-                      assumeNoImportSideEffects:
-                        fusionConfig.assumeNoImportSideEffects,
-                      runtime:
-                        target === 'node' ? 'node-bundled' : 'browser-legacy',
-                      specOnly: false,
-                    }),
+                    ...babelOverrides,
                   },
                 ],
               },

--- a/build/load-fusionrc.js
+++ b/build/load-fusionrc.js
@@ -17,7 +17,7 @@ let loggedNotice = false;
 
 module.exports = function validateConfig(
   dir /*: any */
-) /*: {babel?: {plugins?: Array<any>, presets?: Array<any>}, assumeNoImportSideEffects?: boolean} */ {
+) /*: {babel?: {plugins?: Array<any>, presets?: Array<any>}, assumeNoImportSideEffects?: boolean, experimentalCompile?: boolean} */ {
   const configPath = path.join(dir, '.fusionrc.js');
   let config;
   if (fs.existsSync(configPath)) {
@@ -50,7 +50,9 @@ function isValid(config) {
 
   if (
     !Object.keys(config).every(key =>
-      ['babel', 'assumeNoImportSideEffects'].includes(key)
+      ['babel', 'assumeNoImportSideEffects', 'experimentalCompile'].includes(
+        key
+      )
     )
   ) {
     throw new Error(`Invalid property in .fusionrc.js`);

--- a/test/compiler/api.js
+++ b/test/compiler/api.js
@@ -243,6 +243,36 @@ test('compiles with babel plugin', async t => {
   t.end();
 });
 
+test('experimentalCompile option', async t => {
+  const envs = ['development'];
+  const dir = './test/fixtures/custom-babel';
+  const serverEntryPath = path.resolve(
+    dir,
+    `.fusion/dist/${envs[0]}/server/server-main.js`
+  );
+  const clientEntryPath = path.resolve(
+    dir,
+    `.fusion/dist/${envs[0]}/client/client-main.js`
+  );
+
+  const compiler = new Compiler({envs, dir});
+  await compiler.clean();
+
+  const watcher = await new Promise((resolve, reject) => {
+    const watcher = compiler.start((err, stats) => {
+      if (err || stats.hasErrors()) {
+        return reject(err || new Error('Compiler stats included errors.'));
+      }
+
+      return resolve(watcher);
+    });
+  });
+  watcher.close();
+  t.ok(await exists(clientEntryPath), 'Client file gets compiled');
+  t.ok(await exists(serverEntryPath), 'Server file gets compiled');
+  t.end();
+});
+
 test('transpiles node_modules', async t => {
   const envs = ['development'];
   const dir = './test/fixtures/transpile-node-modules';

--- a/test/fixtures/transpile-all-files/.fusionrc.js
+++ b/test/fixtures/transpile-all-files/.fusionrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  experimentalCompile: true,
+};

--- a/test/fixtures/transpile-all-files/common/test.js
+++ b/test/fixtures/transpile-all-files/common/test.js
@@ -1,0 +1,2 @@
+// @flow
+export const Test: string = 'test';

--- a/test/fixtures/transpile-all-files/src/main.js
+++ b/test/fixtures/transpile-all-files/src/main.js
@@ -1,0 +1,6 @@
+import App from 'fusion-core'; 
+import { Test } from '../common/test';
+
+export default async function() {
+  return new App(Test, el => el);
+}


### PR DESCRIPTION
The `experimentalCompile` flag will tell fusion to run babel with all plugins against every bundled file. After we confirm this approach is viable, we will remove this flag and make it the default behavior in a breaking change. Among other things, this allows projects to have source files outside of `src` with no additional configuration which is useful when using fusion in a monorepo.