### PR TITLE
Fix chunk hashing, refactor JS asset code

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -81,6 +81,10 @@ function getConfig({target, env, dir, watch, state}) {
     __dirname,
     `../entries/server-public-path.js`
   );
+  const clientPublicPathEntry = path.join(
+    __dirname,
+    `../entries/client-public-path.js`
+  );
   const serverEntry = path.join(__dirname, `../entries/server-entry.js`);
   const clientEntry = path.join(__dirname, `../entries/client-entry.js`);
   const entry = {
@@ -153,6 +157,7 @@ function getConfig({target, env, dir, watch, state}) {
     target,
     entry: {
       main: [
+        target === 'web' && clientPublicPathEntry,
         target === 'node' && serverPublicPathEntry,
         env === 'development' &&
           target === 'web' &&

--- a/build/compiler.js
+++ b/build/compiler.js
@@ -77,6 +77,10 @@ function getConfig({target, env, dir, watch, state}) {
   const appSrcDir = path.resolve(dir, 'src');
   const side = target === 'node' ? 'server' : 'client';
   const destination = path.resolve(dir, `.fusion/dist/${env}/${side}`);
+  const serverPublicPathEntry = path.join(
+    __dirname,
+    `../entries/server-public-path.js`
+  );
   const serverEntry = path.join(__dirname, `../entries/server-entry.js`);
   const clientEntry = path.join(__dirname, `../entries/client-entry.js`);
   const entry = {
@@ -149,6 +153,7 @@ function getConfig({target, env, dir, watch, state}) {
     target,
     entry: {
       main: [
+        target === 'node' && serverPublicPathEntry,
         env === 'development' &&
           target === 'web' &&
           watch &&

--- a/build/loaders/chunk-manifest-loader.js
+++ b/build/loaders/chunk-manifest-loader.js
@@ -1,0 +1,39 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+/* eslint-env node */
+
+/*::
+import type {ClientChunkMetadataContext} from "./loader-context.js";
+*/
+const {clientChunkMetadataContextKey} = require('./loader-context.js');
+
+module.exports = function chunkManifestLoader() {
+  this.cacheable(false);
+  const chunkMetadataState /*: ClientChunkMetadataContext*/ = this[
+    clientChunkMetadataContextKey
+  ];
+  const callback = this.async();
+  chunkMetadataState.result.then(chunkMetadata => {
+    callback(null, generateSource(chunkMetadata));
+  });
+};
+
+function generateSource({chunks, runtimeChunkId, initialChunkIds}) {
+  return [
+    `export const chunks = new Map([${Array.from(chunks)
+      .map(
+        ([id, filename]) =>
+          `[${JSON.stringify(id)}, __webpack_public_path__ + "${filename}"]`
+      )
+      .join(', ')}]);`,
+    `export const runtimeChunkId = ${JSON.stringify(runtimeChunkId)};`,
+    `export const initialChunkIds = new Set(${JSON.stringify(
+      Array.from(initialChunkIds)
+    )});`,
+  ].join('\n');
+}

--- a/build/types.js
+++ b/build/types.js
@@ -14,6 +14,9 @@ export type ClientChunkMetadata = {
   urlMap: Map<number, Map<string, string>>,
   criticalPaths: Array<string>,
   criticalIds: Array<number>,
+  chunks: Map<number | string, string>,
+  runtimeChunkId: number | string,
+  initialChunkIds: Set<number | string>,
 };
 export type ClientChunkMetadataState = DeferredState<ClientChunkMetadata>;
 

--- a/entries/client-entry.js
+++ b/entries/client-entry.js
@@ -9,17 +9,16 @@
 /* eslint-env browser */
 /* global module */
 
-__webpack_public_path__ = window.__FUSION_ASSET_PATH__;
-
-// Require is used and assigned to an identifier to opt out of webpack tree-shaking of ununsed imports
-// See: https://github.com/webpack/webpack/issues/6571
-let some_identifier = require('core-js'); // eslint-disable-line
+import {RoutePrefixToken} from 'fusion-core';
 
 function reload() {
   // $FlowFixMe
   const main = require('__FRAMEWORK_SHARED_ENTRY__'); // eslint-disable-line
   const initialize = main.default || main;
   Promise.resolve(initialize()).then(app => {
+    if (window.__ROUTE_PREFIX__) {
+      app.register(RoutePrefixToken);
+    }
     app.callback().call();
   });
 }

--- a/entries/client-entry.js
+++ b/entries/client-entry.js
@@ -9,32 +9,11 @@
 /* eslint-env browser */
 /* global module */
 
+__webpack_public_path__ = window.__FUSION_ASSET_PATH__;
+
 // Require is used and assigned to an identifier to opt out of webpack tree-shaking of ununsed imports
 // See: https://github.com/webpack/webpack/issues/6571
 let some_identifier = require('core-js'); // eslint-disable-line
-/*
-Webpack has a configuration option called `publicPath`, which determines the
-base path for all assets within an application
-
-The property can be set at runtime by assigning to a magic
-global variable called `__webpack_public_path__`.
-
-We set this value at runtime because its value depends on the
-`ROUTE_PREFIX` and `CDN_URL` environment variables.
-
-The value of the env var is sent from the server to the client
-by the `../get-compilation-metadata.js` file. It creates
-a `window.__WEBPACK_PUBLIC_PATH__` global variable in the entry point html with the
-value from the environment variables above
-
-Webpack compiles the `__webpack_public_path__ = ...` assignment expression
-into `__webpack_require__.p = ...` and uses it for HMR manifest requests
-*/
-
-/* eslint-disable */
-// $FlowFixMe
-__webpack_public_path__ = window.__WEBPACK_PUBLIC_PATH__ + '/';
-/* eslint-enable */
 
 function reload() {
   // $FlowFixMe

--- a/entries/client-public-path.js
+++ b/entries/client-public-path.js
@@ -1,0 +1,10 @@
+/*::
+declare var __webpack_public_path__: string;
+*/
+
+// eslint-disable-next-line
+__webpack_public_path__ = window.__FUSION_ASSET_PATH__;
+
+// Require is used and assigned to an identifier to opt out of webpack tree-shaking of ununsed imports
+// See: https://github.com/webpack/webpack/issues/6571
+let some_identifier = require('core-js'); // eslint-disable-line

--- a/entries/server-entry.js
+++ b/entries/server-entry.js
@@ -8,40 +8,28 @@
 
 /* eslint-env node */
 
-import http from 'http';
-
-import {createPlugin, getEnv, HttpServerToken} from 'fusion-core';
-
-import AssetsFactory from '../plugins/assets-plugin';
-import ContextPlugin from '../plugins/context-plugin';
-import ServerErrorPlugin from '../plugins/server-error-plugin';
-import stripRoutePrefix from '../lib/strip-prefix.js';
-
 // $FlowFixMe
 import '__SECRET_I18N_MANIFEST_INSTRUMENTATION_LOADER__!'; // eslint-disable-line
 
-const {prefix, webpackPublicPath} = getEnv();
+import http from 'http';
 
+import {
+  createPlugin,
+  HttpServerToken,
+  RoutePrefixToken,
+  SSRBodyTemplateToken,
+} from 'fusion-core';
+
+import AssetsFactory from '../plugins/assets-plugin';
+import RoutePrefixPlugin from '../plugins/route-prefix-plugin';
+import ContextPlugin from '../plugins/context-plugin';
+import ServerErrorPlugin from '../plugins/server-error-plugin';
+import {SSRBodyTemplate} from '../plugins/ssr-plugin';
+import stripRoutePrefix from '../lib/strip-prefix.js';
+
+let prefix = process.env.ROUTE_PREFIX;
 let AssetsPlugin;
 
-/*
-Webpack has a configuration option called `publicPath`, which determines the
-base path for all assets within an application
-
-The property can be set at runtime by assigning to a magic
-global variable called `__webpack_public_path__`.
-
-We set this value at runtime because its value depends on the
-`ROUTE_PREFIX` and `CDN_URL` environment variables.
-
-Webpack compiles the `__webpack_public_path__ = ...` assignment expression
-into `__webpack_require__.p = ...` and uses it for HMR manifest requests
-*/
-// $FlowFixMe
-__webpack_public_path__ = webpackPublicPath + '/'; // eslint-disable-line
-
-// The shared entry must be imported after setting __webpack_public_path__.
-// We use a require as imports are hoisted and would be run before setting __webpack_public_path__.
 // $FlowFixMe
 const main = require('__FRAMEWORK_SHARED_ENTRY__'); // eslint-disable-line import/no-unresolved, import/no-extraneous-dependencies
 
@@ -81,6 +69,11 @@ async function reload() {
   const app = await initialize();
   reverseRegister(app, AssetsPlugin);
   reverseRegister(app, ContextPlugin);
+  reverseRegister(app, SSRBodyTemplateToken, SSRBodyTemplate);
+  if (prefix) {
+    app.register(RoutePrefixToken, prefix);
+    app.register(RoutePrefixPlugin);
+  }
   if (server) {
     app.register(HttpServerToken, createPlugin({provides: () => server}));
   }

--- a/entries/server-entry.js
+++ b/entries/server-entry.js
@@ -18,10 +18,11 @@ import {
   HttpServerToken,
   RoutePrefixToken,
   SSRBodyTemplateToken,
+  CriticalChunkIdsToken,
 } from 'fusion-core';
 
+import CriticalChunkIdsPlugin from '../plugins/critical-chunk-ids-plugin.js';
 import AssetsFactory from '../plugins/assets-plugin';
-import RoutePrefixPlugin from '../plugins/route-prefix-plugin';
 import ContextPlugin from '../plugins/context-plugin';
 import ServerErrorPlugin from '../plugins/server-error-plugin';
 import {SSRBodyTemplate} from '../plugins/ssr-plugin';
@@ -70,9 +71,9 @@ async function reload() {
   reverseRegister(app, AssetsPlugin);
   reverseRegister(app, ContextPlugin);
   reverseRegister(app, SSRBodyTemplateToken, SSRBodyTemplate);
+  app.register(CriticalChunkIdsToken, CriticalChunkIdsPlugin);
   if (prefix) {
     app.register(RoutePrefixToken, prefix);
-    app.register(RoutePrefixPlugin);
   }
   if (server) {
     app.register(HttpServerToken, createPlugin({provides: () => server}));

--- a/entries/server-public-path.js
+++ b/entries/server-public-path.js
@@ -7,6 +7,11 @@
  */
 
 /* eslint-env node */
+
+/*::
+declare var __webpack_public_path__: string;
+*/
+
 import assert from 'assert';
 import {URL} from 'url';
 
@@ -28,6 +33,7 @@ if (prefix) {
   assetBasePath = prefix + assetBasePath;
 }
 
+// eslint-disable-next-line
 __webpack_public_path__ = cdnUrl ? cdnUrl + '/' : assetBasePath;
 
 function load(key) {

--- a/entries/server-public-path.js
+++ b/entries/server-public-path.js
@@ -1,0 +1,39 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-env node */
+import assert from 'assert';
+import {URL} from 'url';
+
+let prefix = load('ROUTE_PREFIX');
+if (typeof prefix === 'string') {
+  assert(!prefix.endsWith('/'), 'ROUTE_PREFIX must not end with /');
+  assert(prefix.startsWith('/'), 'ROUTE_PREFIX must start with /');
+}
+
+let cdnUrl = load('CDN_URL');
+if (typeof cdnUrl === 'string') {
+  assert(!cdnUrl.endsWith('/'), 'CDN_URL must not end with /');
+  assert(new URL(cdnUrl), 'CDN_URL must be valid absolute URL');
+}
+
+let assetBasePath = '/_static/';
+
+if (prefix) {
+  assetBasePath = prefix + assetBasePath;
+}
+
+__webpack_public_path__ = cdnUrl ? cdnUrl + '/' : assetBasePath;
+
+function load(key) {
+  const value = process.env[key];
+  if (value === null) {
+    return void 0;
+  }
+  return value;
+}

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "fusion-core": "1.7.0-1",
     "fusion-plugin-i18n-react": "^1.0.4",
     "fusion-plugin-react-router": "^1.3.0",
-    "fusion-react": "1.3.0-alpha.0",
+    "fusion-react": "1.3.0-0",
     "fusion-test-utils": "^1.2.2",
     "fusion-tokens": "^1.1.0",
     "prettier": "1.14.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "uglifyjs-webpack-plugin": "^1.3.0",
     "webpack": "4.18.1",
     "webpack-hot-middleware": "^2.24.0",
+    "webpack-plugin-hash-output": "^3.1.0",
     "winston": "^3.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -74,10 +74,10 @@
     "eslint-plugin-prettier": "2.6.2",
     "eslint-plugin-react": "^7.11.1",
     "flow-bin": "0.80.0",
-    "fusion-core": "1.7.0-alpha.2",
+    "fusion-core": "1.7.0-1",
     "fusion-plugin-i18n-react": "^1.0.4",
     "fusion-plugin-react-router": "^1.3.0",
-    "fusion-react": "^1.2.2",
+    "fusion-react": "1.3.0-alpha.0",
     "fusion-test-utils": "^1.2.2",
     "fusion-tokens": "^1.1.0",
     "prettier": "1.14.2",
@@ -89,7 +89,7 @@
     "tape": "4.9.1"
   },
   "peerDependencies": {
-    "fusion-core": "^1.7.0-alpha.2",
+    "fusion-core": "^1.7.0-1",
     "fusion-tokens": "^1.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "eslint-plugin-prettier": "2.6.2",
     "eslint-plugin-react": "^7.11.1",
     "flow-bin": "0.80.0",
-    "fusion-core": "1.5.2",
+    "fusion-core": "1.7.0-alpha.2",
     "fusion-plugin-i18n-react": "^1.0.4",
     "fusion-plugin-react-router": "^1.3.0",
     "fusion-react": "^1.2.2",
@@ -89,7 +89,7 @@
     "tape": "4.9.1"
   },
   "peerDependencies": {
-    "fusion-core": "^1.5.0",
+    "fusion-core": "^1.7.0-alpha.2",
     "fusion-tokens": "^1.1.0"
   },
   "engines": {

--- a/plugins/context-plugin.js
+++ b/plugins/context-plugin.js
@@ -22,7 +22,6 @@ module.exports = createPlugin({
       // webpack-related things
       ctx.syncChunks = compilationMetaData.syncChunks;
       ctx.chunkUrlMap = compilationMetaData.chunkUrlMap;
-
       return next();
     };
   },

--- a/plugins/critical-chunk-ids-plugin.js
+++ b/plugins/critical-chunk-ids-plugin.js
@@ -8,12 +8,19 @@
 
 /* eslint-env node */
 
-const {createPlugin, memoize} = require('fusion-core');
+import {createPlugin, memoize} from 'fusion-core';
 
-module.exports = createPlugin({
+// $FlowFixMe
+import {initialChunkIds} from '../build/loaders/chunk-manifest-loader.js!'; // eslint-disable-line
+
+export default createPlugin({
   provides: () => {
     return {
       from: memoize(() => {
+        const chunkIds = new Set();
+        for (const chunkId of initialChunkIds) {
+          chunkIds.add(chunkId);
+        }
         return new Set();
       }),
     };

--- a/plugins/critical-chunk-ids-plugin.js
+++ b/plugins/critical-chunk-ids-plugin.js
@@ -8,15 +8,14 @@
 
 /* eslint-env node */
 
-/*
-Hack to stop from complaining.
-*/
-
-const {createPlugin, RoutePrefixToken} = require('fusion-core');
+const {createPlugin, memoize} = require('fusion-core');
 
 module.exports = createPlugin({
-  deps: {
-    routePrefix: RoutePrefixToken,
+  provides: () => {
+    return {
+      from: memoize(() => {
+        return new Set();
+      }),
+    };
   },
-  provides: () => {},
 });

--- a/plugins/route-prefix-plugin.js
+++ b/plugins/route-prefix-plugin.js
@@ -1,0 +1,22 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-env node */
+
+/*
+Hack to stop from complaining.
+*/
+
+const {createPlugin, RoutePrefixToken} = require('fusion-core');
+
+module.exports = createPlugin({
+  deps: {
+    routePrefix: RoutePrefixToken,
+  },
+  provides: () => {},
+});

--- a/plugins/ssr-plugin.js
+++ b/plugins/ssr-plugin.js
@@ -61,7 +61,7 @@ const SSRBodyTemplate = createPlugin({
         `<script nonce="${ctx.nonce}">`,
         `window.performance && window.performance.mark && window.performance.mark('firstRenderStart');`,
         routePrefix && `__ROUTE_PREFIX__ = ${JSON.stringify(routePrefix)};`,
-        `__FUSION_ASSET_PATH__ = ${JSON.stringify(__webpack_public_path__)};`, // consumed by fusion-clientries/client-entry
+        `__FUSION_ASSET_PATH__ = ${JSON.stringify(__webpack_public_path__)};`, // consumed in src/entries/client-public-path.js
         `</script>`,
       ]
         .filter(Boolean)

--- a/plugins/ssr-plugin.js
+++ b/plugins/ssr-plugin.js
@@ -1,0 +1,126 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+/* eslint-env node */
+
+/*::
+import type {
+  Context,
+  SSRBodyTemplate as SSRBodyTemplateService,
+} from 'fusion-core';
+*/
+
+import {
+  createPlugin,
+  escape,
+  consumeSanitizedHTML,
+  CriticalChunkIdsToken,
+} from 'fusion-core';
+
+const SSRBodyTemplate = createPlugin({
+  deps: {
+    criticalChunkIds: CriticalChunkIdsToken.optional,
+  },
+  provides: ({criticalChunkIds}) => {
+    return ctx => {
+      const {htmlAttrs, bodyAttrs, title, head, body} = ctx.template;
+      const safeAttrs = Object.keys(htmlAttrs)
+        .map(attrKey => {
+          return ` ${escape(attrKey)}="${escape(htmlAttrs[attrKey])}"`;
+        })
+        .join('');
+
+      const safeBodyAttrs = Object.keys(bodyAttrs)
+        .map(attrKey => {
+          return ` ${escape(attrKey)}="${escape(bodyAttrs[attrKey])}"`;
+        })
+        .join('');
+
+      const safeTitle = escape(title);
+      // $FlowFixMe
+      const safeHead = head.map(consumeSanitizedHTML).join('');
+      // $FlowFixMe
+      const safeBody = body.map(consumeSanitizedHTML).join('');
+
+      const preloadHintLinks = getPreloadHintLinks(ctx);
+      const coreGlobals = getCoreGlobals(ctx);
+      const chunkScripts = getChunkScripts(ctx);
+      const bundleSplittingBootstrap = [
+        preloadHintLinks,
+        coreGlobals,
+        chunkScripts,
+      ].join('');
+
+      return [
+        '<!doctype html>',
+        `<html${safeAttrs}>`,
+        `<head>`,
+        `<meta charset="utf-8" />`,
+        `<title>${safeTitle}</title>`,
+        `${bundleSplittingBootstrap}${safeHead}`,
+        `</head>`,
+        `<body${safeBodyAttrs}>${ctx.rendered}${safeBody}</body>`,
+        '</html>',
+      ].join('');
+    };
+  },
+});
+
+export {SSRBodyTemplate};
+
+function getCoreGlobals(ctx) {
+  const {nonce} = ctx;
+
+  return [
+    `<script nonce="${nonce}">`,
+    `window.performance && window.performance.mark && window.performance.mark('firstRenderStart');`,
+    `__ROUTE_PREFIX__ = ${JSON.stringify(ctx.prefix)};`, // consumed by ./client
+    `__FUSION_ASSET_PATH__ = ${JSON.stringify(__webpack_public_path__)};`, // consumed by fusion-clientries/client-entry
+    `</script>`,
+  ].join('');
+}
+
+function getUrls({chunkUrlMap}, chunks) {
+  return [...new Set(chunks)].map(id => {
+    let url = chunkUrlMap.get(id).get('es5');
+    return {id, url};
+  });
+}
+
+function getChunkScripts(ctx) {
+  const sync = getUrls(ctx, ctx.syncChunks).map(({url}) => {
+    // cross origin is needed to get meaningful errors in window.onerror
+    const crossOrigin = url.startsWith('https://')
+      ? ' crossorigin="anonymous"'
+      : '';
+
+    return `<script nonce="${
+      ctx.nonce
+    }" defer${crossOrigin} src="${url}"></script>`;
+  });
+  const preloaded = getUrls(
+    ctx,
+    ctx.preloadChunks.filter(item => !ctx.syncChunks.includes(item))
+  ).map(({id, url}) => {
+    // cross origin is needed to get meaningful errors in window.onerror
+    const crossOrigin = url.startsWith('https://')
+      ? ' crossorigin="anonymous"'
+      : '';
+    return `<script nonce="${
+      ctx.nonce
+    }" defer${crossOrigin} src="${url}"></script>`;
+  });
+  return [...preloaded, ...sync].join('');
+}
+
+function getPreloadHintLinks(ctx) {
+  const chunks = [...ctx.preloadChunks, ...ctx.syncChunks];
+  const hints = getUrls(ctx, chunks).map(({url}) => {
+    return `<link rel="preload" href="${url}" as="script" />`;
+  });
+  return hints.join('');
+}

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -166,7 +166,6 @@ test('`fusion build` app with dynamic imports chunk hashing', async t => {
     rebuiltDistFiles.clientVendorFile,
     'vendor file hash should not change'
   );
-  // TODO(#393) Add this back https://github.com/fusionjs/fusion-cli/pull/385
   t.equal(
     distFiles.clientMainFile,
     rebuiltDistFiles.clientMainFile,

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -167,11 +167,11 @@ test('`fusion build` app with dynamic imports chunk hashing', async t => {
     'vendor file hash should not change'
   );
   // TODO(#393) Add this back https://github.com/fusionjs/fusion-cli/pull/385
-  // t.equal(
-  //   distFiles.clientMainFile,
-  //   rebuiltDistFiles.clientMainFile,
-  //   'main file hash should not change'
-  // );
+  t.equal(
+    distFiles.clientMainFile,
+    rebuiltDistFiles.clientMainFile,
+    'main file hash should not change'
+  );
   t.notEqual(
     distFiles.splitClientChunks[splitChunkId],
     rebuiltDistFiles.splitClientChunks[splitChunkId],
@@ -205,15 +205,15 @@ test('`fusion build` app with dynamic imports integration', async t => {
   );
   t.equal(
     await page.$$eval('script', els => els.length),
-    5,
-    'should be 5 scripts'
+    6,
+    'should be 6 scripts'
   );
   await page.click('#split-route-link');
 
   t.equal(
     await page.$$eval('script', els => els.length),
-    6,
-    'should be 6 scripts after dynamic loading'
+    7,
+    'should be 7 scripts after dynamic loading'
   );
 
   t.ok(
@@ -221,6 +221,15 @@ test('`fusion build` app with dynamic imports integration', async t => {
       els.every(el => el.crossOrigin === null)
     ),
     'all scripts do not have crossorigin attribute'
+  );
+
+  page.setJavaScriptEnabled(false);
+
+  await page.goto(`http://localhost:${port}/split-route`, {waitUntil: 'load'});
+  t.equal(
+    await page.$$eval('script', els => els.length),
+    7,
+    'all critical scripts should be preloaded'
   );
 
   await browser.close();
@@ -490,12 +499,10 @@ test('`fusion build` with dynamic imports', async t => {
   t.deepEqual(testContent.chunkIds, [[1], [0]], 'Chunk IDs are populated');
 
   t.ok(
-    await exists(path.resolve(dir, `.fusion/dist/development/client/0.js`)),
+    await exists(
+      path.resolve(dir, `.fusion/dist/development/client/client-0.js`)
+    ),
     'client dynamic import bundle exists'
-  );
-  t.ok(
-    await exists(path.resolve(dir, `.fusion/dist/development/server/0.js`)),
-    'server dynamic import bundle exists'
   );
   t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3192,9 +3192,9 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-fusion-core@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.5.2.tgz#025c0be54993993ed256168fa670ccd5d75811e3"
+fusion-core@1.7.0-alpha.2:
+  version "1.7.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.7.0-alpha.2.tgz#f2279a57b93d4e19b468d106402accd1bafdef9f"
   dependencies:
     koa "^2.4.1"
     koa-compose "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3231,9 +3231,9 @@ fusion-plugin-universal-events@^1.1.0:
   dependencies:
     koa-bodyparser "4.2.1"
 
-fusion-react@1.3.0-alpha.0:
-  version "1.3.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/fusion-react/-/fusion-react-1.3.0-alpha.0.tgz#15d0bdec72407d48f3835367cda1adc5bac19d63"
+fusion-react@1.3.0-0:
+  version "1.3.0-0"
+  resolved "https://registry.yarnpkg.com/fusion-react/-/fusion-react-1.3.0-0.tgz#4b81628045e9b99a621d24af75b8d5394663774e"
   dependencies:
     prop-types "^15.6.2"
     react-is "^16.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3192,9 +3192,9 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-fusion-core@1.7.0-alpha.2:
-  version "1.7.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.7.0-alpha.2.tgz#f2279a57b93d4e19b468d106402accd1bafdef9f"
+fusion-core@1.7.0-1:
+  version "1.7.0-1"
+  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.7.0-1.tgz#a238445a1e0e164269f1946578651edcfc421db9"
   dependencies:
     koa "^2.4.1"
     koa-compose "^4.0.0"
@@ -3231,9 +3231,9 @@ fusion-plugin-universal-events@^1.1.0:
   dependencies:
     koa-bodyparser "4.2.1"
 
-fusion-react@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/fusion-react/-/fusion-react-1.2.2.tgz#51570a407c1c92eccf43c14ced331e3e7d71cb2f"
+fusion-react@1.3.0-alpha.0:
+  version "1.3.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/fusion-react/-/fusion-react-1.3.0-alpha.0.tgz#15d0bdec72407d48f3835367cda1adc5bac19d63"
   dependencies:
     prop-types "^15.6.2"
     react-is "^16.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7413,6 +7413,10 @@ webpack-hot-middleware@^2.24.0:
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
 
+webpack-plugin-hash-output@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-plugin-hash-output/-/webpack-plugin-hash-output-3.1.0.tgz#160bb42dd5b3d6f6e05201a722cf553c3687f95c"
+
 webpack-sources@^1.0.1, webpack-sources@^1.1.0, webpack-sources@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.2.0.tgz#18181e0d013fce096faf6f8e6d41eeffffdceac2"


### PR DESCRIPTION
- Move `__webpack_public_path__` code into their own files. This is less error prone because it is guaranteed to come first before other code (because those files are placed first in the entries array), so no need to worry about hoisted imports, etc.
- Configure webpack to use a runtime chunk which is required for long-term caching of chunks. This runtime chunk is invalidated for every change but is tiny; the remaining chunks only change when modified.
- Add md5 hashing of chunks, which makes hashes deterministic based on file contents. Without this, hashes would not change if uglify settings were changed (for example) See: https://github.com/webpack/webpack/issues/4659 for more info
- Enforce that the server bundle has only one chunk
- Register RoutePrefixToken, which will be consumed by newer packages instead of the context property. This token should be registered in fusion-cli because the prefix stripping code also lives in fusion-cli. Eventually we should move probably move all route prefixing code into a separate plugin.
- Register CriticalChunkIds, which will be consumed by newer versions of fusion-react, etc.
- Register SSRBodyTemplate, which will replace the legacy template used in fusion-core. For backwards compat, this template uses both the legacy `ctx.preloadChunks` as well as the new `CriticalChunkIds` token.
- Remove preload hints, which won't be compatible with serving both `<script type="module">` and `<script>` bundles.

Fixes https://github.com/fusionjs/fusion-cli/issues/393