### PR TITLE
Add nodeBuiltins option to fusionrc.js, remove unused and undocumented config

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -68,11 +68,6 @@ function getConfig({target, env, dir, watch, state}) {
 
   const fusionConfig = loadFusionRC(dir);
 
-  const configPath = path.join(dir, 'package.json');
-  // $FlowFixMe
-  const configData = fs.existsSync(configPath) ? require(configPath) : {};
-  const {pragma, clientHotLoaderEntry, node, alias} = configData;
-
   const name = {node: 'server', web: 'client'}[target];
   const appBase = path.resolve(dir);
   const appSrcDir = path.resolve(dir, 'src');
@@ -96,7 +91,6 @@ function getConfig({target, env, dir, watch, state}) {
   const babelConfig = fusionConfig.experimentalCompile
     ? getBabelConfig({
         dev: env === 'development',
-        jsx: {pragma},
         fusionTransforms: true,
         assumeNoImportSideEffects: fusionConfig.assumeNoImportSideEffects,
         runtime: target === 'node' ? 'node-bundled' : 'browser-legacy',
@@ -127,7 +121,6 @@ function getConfig({target, env, dir, watch, state}) {
     ? {}
     : getBabelConfig({
         dev: env === 'development',
-        jsx: {pragma},
         fusionTransforms: true,
         assumeNoImportSideEffects: fusionConfig.assumeNoImportSideEffects,
         runtime: target === 'node' ? 'node-bundled' : 'browser-legacy',
@@ -160,11 +153,6 @@ function getConfig({target, env, dir, watch, state}) {
       main: [
         target === 'web' && clientPublicPathEntry,
         target === 'node' && serverPublicPathEntry,
-        env === 'development' &&
-          target === 'web' &&
-          watch &&
-          clientHotLoaderEntry &&
-          resolveFrom(appBase, clientHotLoaderEntry),
         env === 'development' &&
           watch &&
           target !== 'node' &&
@@ -226,7 +214,7 @@ function getConfig({target, env, dir, watch, state}) {
       hints: false,
     },
     context: dir,
-    node: Object.assign(getNodeConfig(target, env), node),
+    node: getNodeConfig(target, env),
     module: {
       /**
        * Compile-time error for importing a non-existent export
@@ -303,14 +291,11 @@ function getConfig({target, env, dir, watch, state}) {
     ].filter(Boolean),
     resolve: {
       aliasFields: [target === 'web' && 'browser'].filter(Boolean),
-      alias: Object.assign(
-        {
-          // we replace need to set the path to user application at build-time
-          __FRAMEWORK_SHARED_ENTRY__: path.resolve(dir, main),
-          __ENV__: env,
-        },
-        alias
-      ),
+      alias: Object.assign({
+        // we replace need to set the path to user application at build-time
+        __FRAMEWORK_SHARED_ENTRY__: path.resolve(dir, main),
+        __ENV__: env,
+      }),
     },
     resolveLoader: {
       alias: {

--- a/build/load-fusionrc.js
+++ b/build/load-fusionrc.js
@@ -15,9 +15,16 @@ const chalk = require('chalk');
 
 let loggedNotice = false;
 
-module.exports = function validateConfig(
-  dir /*: any */
-) /*: {babel?: {plugins?: Array<any>, presets?: Array<any>}, assumeNoImportSideEffects?: boolean, experimentalCompile?: boolean} */ {
+/*::
+type FusionRC = {
+  babel?: {plugins?: Array<any>, presets?: Array<any>},
+  assumeNoImportSideEffects?: boolean,
+  experimentalCompile?: boolean,
+  nodeBuiltins?: {[string]: any},
+};
+*/
+
+module.exports = function validateConfig(dir /*: any */) /*: FusionRC */ {
   const configPath = path.join(dir, '.fusionrc.js');
   let config;
   if (fs.existsSync(configPath)) {
@@ -50,9 +57,12 @@ function isValid(config) {
 
   if (
     !Object.keys(config).every(key =>
-      ['babel', 'assumeNoImportSideEffects', 'experimentalCompile'].includes(
-        key
-      )
+      [
+        'babel',
+        'assumeNoImportSideEffects',
+        'experimentalCompile',
+        'nodeBuiltins',
+      ].includes(key)
     )
   ) {
     throw new Error(`Invalid property in .fusionrc.js`);

--- a/build/load-fusionrc.js
+++ b/build/load-fusionrc.js
@@ -24,7 +24,7 @@ type FusionRC = {
 };
 */
 
-module.exports = function validateConfig(dir /*: any */) /*: FusionRC */ {
+module.exports = function validateConfig(dir /*: string */) /*: FusionRC */ {
   const configPath = path.join(dir, '.fusionrc.js');
   let config;
   if (fs.existsSync(configPath)) {

--- a/docs/fusionrc.md
+++ b/docs/fusionrc.md
@@ -28,7 +28,7 @@ By default this is `false`.
 
 Setting this to `true` enables the assumption that modules in your code do not have any import side effects. This assumption allows for more powerful tree shaking and pruning of unused imports.
 
-This option may be useful if you import modules that use Node.js built-ins. This option makes it easier to avoid uninintionally including server-specific code in the browser bundle.
+This option may be useful if you import modules that use Node.js built-ins. This option makes it easier to avoid unintentionally including server-specific code in the browser bundle.
 
 For specifics regarding implementation details, see:
  - https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
@@ -36,3 +36,7 @@ For specifics regarding implementation details, see:
  - https://stackoverflow.com/questions/49160752/what-does-webpack-4-expect-from-a-package-with-sideeffects-false/49203452#49203452
 
 In the future, it is possible that some form of this behavior may be turned on by default (with ways to opt-out instead).
+
+## `nodeBuiltins`
+
+This is an optional property that can be used to override the Fusion.js defaults for https://webpack.js.org/configuration/node/ in the browser bundle.

--- a/docs/fusionrc.md
+++ b/docs/fusionrc.md
@@ -10,7 +10,7 @@ This configuration object supports the following fields:
 
 For example, to add your own Babel plugins/preset:
 
-```
+```js
 module.exports = {
   babel: {
     presets: ["some-babel-preset"],
@@ -40,3 +40,11 @@ In the future, it is possible that some form of this behavior may be turned on b
 ## `nodeBuiltins`
 
 This is an optional property that can be used to override the Fusion.js defaults for https://webpack.js.org/configuration/node/ in the browser bundle.
+
+```js
+module.exports = {
+  nodeBuiltins: {
+    Buffer: true
+  }
+};
+```

--- a/test/cli/dev.js
+++ b/test/cli/dev.js
@@ -137,6 +137,38 @@ test('`fusion dev` works with assetUrl and JSON assets', async t => {
   t.end();
 });
 
+test('`fusion dev` works with fusionRC', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/fusionrc');
+  let browser;
+  const {proc, port} = await dev(`--dir=${dir}`);
+
+  try {
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+    const page = await browser.newPage();
+    await page.goto(`http://localhost:${port}/`, {
+      waitUntil: 'load',
+    });
+
+    const browserBufferContents = await page.evaluate(
+      // $FlowFixMe
+      () => window.__browser_buffer_test__ // eslint-disable-line
+    );
+
+    t.equal(
+      browserBufferContents,
+      'buffer',
+      'Buffer shim override in browser works'
+    );
+  } catch (e) {
+    t.iferror(e);
+  }
+  await (browser && browser.close());
+  proc.kill();
+  t.end();
+});
+
 test('`fusion dev` assets work with route prefix', async t => {
   const dir = path.resolve(__dirname, '../fixtures/assets');
   const entryPath = path.resolve(

--- a/test/fixtures/fusionrc/.fusionrc.js
+++ b/test/fixtures/fusionrc/.fusionrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  nodeBuiltins: {
+    Buffer: true
+  }
+};

--- a/test/fixtures/fusionrc/src/main.js
+++ b/test/fixtures/fusionrc/src/main.js
@@ -1,0 +1,10 @@
+import App from 'fusion-core';
+
+if (__BROWSER__) {
+  window.__browser_buffer_test__ = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]).toString();
+}
+
+export default async function() {
+  const app = new App('element', el => el);
+  return app;
+}


### PR DESCRIPTION
**Summary**
- Deprecates undocumented top-level "node" package.json field
- Removes code for undocumented and unused top-level "alias", "pragma", and "clientHotLoaderEntry" package.json fields
- Adds documented "nodeBuiltins" `.fusionrc.js` property that does the same thing
- Adds test to ensure "nodeBuiltins" `.fusionrc.js` property is respected

This is vestigial code from the initial OSS commit. These package.json configuration options are completely undocumented. Sourcegraph did not yield results for any actual usage of these package.json fields except for "node".

This PR adds a documented .fusionrc.js property that replaces the top-level "node" field.

Because the other fields are not used by anyone and were never documented nor part of the canonical public API, I think removing them should not be considered a breaking change.