### PR TITLE
Remove vestigial webpack-dev-server config

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -218,10 +218,6 @@ function getConfig({target, env, dir, watch, state}) {
           : path.resolve(appBase, info.absoluteResourcePath);
       },
     },
-    devServer: {
-      contentBase: '.',
-      hot: true,
-    },
     performance: {
       hints: false,
     },


### PR DESCRIPTION
We don't use webpack-dev-server anymore so this configuration is not used by anything.