### PR TITLE
Update snapshot command in test

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "path-is-absolute": "^1.0.1",
     "progress-bar-webpack-plugin": "^1.11.0",
     "range-parser": "^1.2.0",
-    "react-dev-utils": "^6.0.3",
+    "react-dev-utils": "^6.0.4",
     "request": "^2.88.0",
     "resolve-from": "^4.0.0",
     "rimraf": "^2.6.2",

--- a/test/cli/test.js
+++ b/test/cli/test.js
@@ -191,8 +191,7 @@ test('`fusion test` snapshotting - enzyme serializer', async t => {
     t.equal(countTests(e.message), 2, 'ran 2 tests');
   }
 
-  const updateSnapshot = `require('${runnerPath}').run('node ${runnerPath} ${args} --updateSnapshot')`;
-  await exec(`node -e "${updateSnapshot}"`);
+  await exec(`node ${runnerPath} ${args} --updateSnapshot`);
 
   const newSnapshotCode = await readFile(snapshotFile);
   const originalSnapshotCode = await readFile(backupSnapshot);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5931,9 +5931,9 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dev-utils@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-6.0.3.tgz#78662b5fd7b4441140485e80d04d594116c5b1e3"
+react-dev-utils@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-6.0.4.tgz#cd6d2712aa22d67751ef6757dc82787351da8826"
   dependencies:
     "@babel/code-frame" "7.0.0"
     address "1.0.3"
@@ -5951,7 +5951,7 @@ react-dev-utils@^6.0.3:
     loader-utils "1.1.0"
     opn "5.4.0"
     pkg-up "2.0.0"
-    react-error-overlay "^5.0.3"
+    react-error-overlay "^5.0.4"
     recursive-readdir "2.2.2"
     shell-quote "1.6.1"
     sockjs-client "1.1.5"
@@ -5967,9 +5967,9 @@ react-dom@^16.5.2:
     prop-types "^15.6.2"
     schedule "^0.5.0"
 
-react-error-overlay@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.0.3.tgz#6eae9350144f3cd036e4f968c5a8bfae542af562"
+react-error-overlay@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.0.4.tgz#39cf184d770f98b65a2ee59a779d03b8d092b69e"
 
 react-is@^16.4.2, react-is@^16.5.2:
   version "16.5.2"


### PR DESCRIPTION
Seems this is necessary for release verification. I'm not sure why, but we've had problems with node -e in the past.