### PR TITLE
Fix incorrect sourcemap filenames

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -14,7 +14,6 @@ const path = require('path');
 const webpack = require('webpack');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const ProgressBarPlugin = require('progress-bar-webpack-plugin');
-const HashOutputPlugin = require('webpack-plugin-hash-output');
 const webpackDevMiddleware = require('../lib/simple-webpack-dev-middleware');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const {
@@ -383,8 +382,6 @@ function getConfig({target, env, dir, watch, state}) {
           banner: nodeEnvBanner,
         }),
       new webpack.EnvironmentPlugin({NODE_ENV: nodeEnv}),
-      // webpack chunkhash doesn't take into account uglify. This uses exact md5 hashing
-      target === 'web' && env === 'production' && new HashOutputPlugin(),
     ].filter(Boolean),
     optimization: {
       minimizer:

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "uglifyjs-webpack-plugin": "^2.0.1",
     "webpack": "4.20.2",
     "webpack-hot-middleware": "^2.24.2",
-    "webpack-plugin-hash-output": "^3.1.0",
     "winston": "^3.1.0"
   },
   "devDependencies": {

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -394,6 +394,16 @@ test('`fusion build` works in production', async t => {
     res.includes('src="/_static/client-vendor'),
     'includes a script reference to client-vendor'
   );
+
+  clientFiles.forEach(file => {
+    if (file.endsWith('.map')) {
+      t.ok(
+        clientFiles.includes(path.basename(file, '.map')),
+        'source map filename has same base as regular file'
+      );
+    }
+  });
+
   proc.kill();
   t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7331,10 +7331,6 @@ webpack-hot-middleware@^2.24.2:
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
 
-webpack-plugin-hash-output@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/webpack-plugin-hash-output/-/webpack-plugin-hash-output-3.1.0.tgz#160bb42dd5b3d6f6e05201a722cf553c3687f95c"
-
 webpack-sources@^1.0.1, webpack-sources@^1.1.0, webpack-sources@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"


### PR DESCRIPTION
webpack-plugin-hash-output was not also renaming source map files. This meant that the source map files had a different basename than the JS chunks.

Removing for now until this is fixed.

Note: this means changing uglify settings will yield hash collisions. So we should put back this behavior once the problem is addressed.