### PR TITLE
Fix client-side RoutePrefixToken registration

### DIFF
--- a/entries/client-entry.js
+++ b/entries/client-entry.js
@@ -17,7 +17,7 @@ function reload() {
   const initialize = main.default || main;
   Promise.resolve(initialize()).then(app => {
     if (window.__ROUTE_PREFIX__) {
-      app.register(RoutePrefixToken);
+      app.register(RoutePrefixToken, window.__ROUTE_PREFIX__);
     }
     app.callback().call();
   });

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -354,6 +354,32 @@ test('`fusion build/start with ROUTE_PREFIX and custom routes`', async t => {
     'TEST REQUEST',
     'strips route prefix correctly for deep path requests'
   );
+
+  const tokenRes = await request(
+    `http://localhost:${port}/test-prefix/server-token`
+  );
+  t.equal(tokenRes, '/test-prefix', 'server-side RoutePrefixToken is set');
+
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const page = await browser.newPage();
+  await page.goto(`http://localhost:${port}/test-prefix/ssr`, {
+    waitUntil: 'load',
+  });
+
+  const clientRoutePrefixTokenValue = await page.evaluate(() => {
+    // eslint-disable-next-line
+    return window.__client_route_prefix_token_value__;
+  });
+  t.equal(
+    clientRoutePrefixTokenValue,
+    '/test-prefix',
+    'RoutePrefixToken hydrated on client'
+  );
+
+  await browser.close();
+
   proc.kill();
   t.end();
 });

--- a/test/fixtures/prefix/src/main.js
+++ b/test/fixtures/prefix/src/main.js
@@ -1,4 +1,4 @@
-import App from 'fusion-core';
+import App, {createPlugin, RoutePrefixToken} from 'fusion-core';
 
 export default async function() {
   const app = new App('element', el => el);
@@ -10,5 +10,22 @@ export default async function() {
     }
     return next();
   });
+  app.register(createPlugin({
+    deps: {
+      routePrefix: RoutePrefixToken
+    },
+    middleware({routePrefix}) {
+      return (ctx, next) => {
+        if (ctx.url === "/server-token") {
+          ctx.body = routePrefix;
+          return next();
+        }
+        if (__BROWSER__) {
+          window.__client_route_prefix_token_value__ = routePrefix;
+        }
+        return next();
+      }
+    }
+  }));
   return app;
 }


### PR DESCRIPTION
This isn't used anywhere yet, but the actual value needs to be registered (just like on the server)