### PR TITLE
Fix client-side token registration error

### DIFF
--- a/entries/client-entry.js
+++ b/entries/client-entry.js
@@ -9,7 +9,7 @@
 /* eslint-env browser */
 /* global module */
 
-import {RoutePrefixToken} from 'fusion-core';
+import {createPlugin, RoutePrefixToken} from 'fusion-core';
 
 function reload() {
   // $FlowFixMe
@@ -17,6 +17,13 @@ function reload() {
   const initialize = main.default || main;
   Promise.resolve(initialize()).then(app => {
     if (window.__ROUTE_PREFIX__) {
+      // No-op plugin so token can be registered without any consumers
+      // Should not be needed when route prefixing is refactored into a separate plugin
+      app.register(
+        createPlugin({
+          deps: {routePrefix: RoutePrefixToken.optional},
+        })
+      );
       app.register(RoutePrefixToken, window.__ROUTE_PREFIX__);
     }
     app.callback().call();

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -384,6 +384,36 @@ test('`fusion build/start with ROUTE_PREFIX and custom routes`', async t => {
   t.end();
 });
 
+test('`fusion start` does not throw error on client when using route prefix', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/noop');
+  await cmd(`build --dir=${dir} --production`);
+  const {proc, port} = await start(`--dir=${dir}`, {
+    env: Object.assign({}, process.env, {ROUTE_PREFIX: '/test-prefix'}),
+  });
+
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const page = await browser.newPage();
+
+  page.on('error', err => {
+    t.fail(`Client-side error: ${err}`);
+  });
+
+  page.on('pageerror', err => {
+    t.fail(`Client-side error: ${err}`);
+  });
+
+  await page.goto(`http://localhost:${port}/test-prefix/`, {
+    waitUntil: 'networkidle0',
+  });
+
+  await browser.close();
+
+  proc.kill();
+  t.end();
+});
+
 test('`fusion build` works in production', async t => {
   const dir = path.resolve(__dirname, '../fixtures/noop');
   const serverEntryPath = path.resolve(

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -411,6 +411,7 @@ test('`fusion start` does not throw error on client when using route prefix', as
   await browser.close();
 
   proc.kill();
+  t.pass('did not error');
   t.end();
 });
 


### PR DESCRIPTION
This PR resolves a client-side error from a token being registered without being used and adds a regression test