### PR TITLE
Fix assetUrl in dev in certain instances

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -40,7 +40,7 @@ const {DeferredState} = require('./shared-state-containers.js');
 const {
   translationsManifestContextKey,
   clientChunkMetadataContextKey,
-  modeKey,
+  devContextKey,
 } = require('./loaders/loader-context.js');
 const ClientChunkMetadataStateHydratorPlugin = require('./plugins/client-chunk-metadata-state-hydrator-plugin.js');
 const InstrumentedImportDependencyTemplatePlugin = require('./plugins/instrumented-import-dependency-template-plugin');
@@ -322,7 +322,7 @@ function getConfig({target, env, dir, watch, state}) {
       target === 'node' &&
         new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1}),
       new ProgressBarPlugin(),
-      new LoaderContextProviderPlugin(modeKey, env),
+      new LoaderContextProviderPlugin(devContextKey, env !== 'production'),
       target === 'web'
         ? new ClientChunkMetadataStateHydratorPlugin(state.clientChunkMetadata)
         : new LoaderContextProviderPlugin(

--- a/build/compiler.js
+++ b/build/compiler.js
@@ -40,6 +40,7 @@ const {DeferredState} = require('./shared-state-containers.js');
 const {
   translationsManifestContextKey,
   clientChunkMetadataContextKey,
+  modeKey,
 } = require('./loaders/loader-context.js');
 const ClientChunkMetadataStateHydratorPlugin = require('./plugins/client-chunk-metadata-state-hydrator-plugin.js');
 const InstrumentedImportDependencyTemplatePlugin = require('./plugins/instrumented-import-dependency-template-plugin');
@@ -321,6 +322,7 @@ function getConfig({target, env, dir, watch, state}) {
       target === 'node' &&
         new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1}),
       new ProgressBarPlugin(),
+      new LoaderContextProviderPlugin(modeKey, env),
       target === 'web'
         ? new ClientChunkMetadataStateHydratorPlugin(state.clientChunkMetadata)
         : new LoaderContextProviderPlugin(

--- a/build/loaders/file-loader.js
+++ b/build/loaders/file-loader.js
@@ -10,21 +10,24 @@
 const path = require('path');
 const fs = require('fs');
 const loaderUtils = require('loader-utils');
-const {modeKey} = require('../loaders/loader-context.js');
+
+/*::
+import type {DevContext} from "./loader-context.js";
+*/
+const {devContextKey} = require('./loader-context.js');
 
 module.exports = function fileLoader(content /*: string */) {
+  const dev /*: DevContext */ = this[devContextKey];
+
   const done = assetContents => {
     const url = loaderUtils.interpolateName(this, '[hash].[ext]', {
       context: this.rootContext,
       content: assetContents,
     });
 
-    // Assets should always go into client dist directory, regardless of source
-    const outputPath = path.posix.join(
-      // memory-fs runs at `/`, so can't have path starting w/ `..` in dev
-      this[modeKey] === 'development' ? '/' : '../client',
-      url
-    );
+    // This should match webpack config.output.path option, except
+    // assets should always go into client dist directory, regardless of source
+    const outputPath = path.posix.join(dev ? '/' : '../client', url);
     this.emitFile(outputPath, assetContents);
     return `module.exports = __webpack_public_path__ + ${JSON.stringify(url)};`;
   };

--- a/build/loaders/file-loader.js
+++ b/build/loaders/file-loader.js
@@ -10,6 +10,7 @@
 const path = require('path');
 const fs = require('fs');
 const loaderUtils = require('loader-utils');
+const {modeKey} = require('../loaders/loader-context.js');
 
 module.exports = function fileLoader(content /*: string */) {
   const done = assetContents => {
@@ -19,7 +20,11 @@ module.exports = function fileLoader(content /*: string */) {
     });
 
     // Assets should always go into client dist directory, regardless of source
-    const outputPath = path.posix.join('../client', url);
+    const outputPath = path.posix.join(
+      // memory-fs runs at `/`, so can't have path starting w/ `..` in dev
+      this[modeKey] === 'development' ? '/' : '../client',
+      url
+    );
     this.emitFile(outputPath, assetContents);
     return `module.exports = __webpack_public_path__ + ${JSON.stringify(url)};`;
   };

--- a/build/loaders/loader-context.js
+++ b/build/loaders/loader-context.js
@@ -36,4 +36,7 @@ exports.translationsDiscoveryKey = Symbol(
   'loader context key for translations discovery'
 );
 
-exports.modeKey = Symbol('mode');
+/*::
+export type DevContext = boolean;
+*/
+exports.devContextKey = Symbol('loader context key for __DEV__ state');

--- a/build/loaders/loader-context.js
+++ b/build/loaders/loader-context.js
@@ -35,3 +35,5 @@ export type TranslationsDiscoveryContext = TranslationsManifest;
 exports.translationsDiscoveryKey = Symbol(
   'loader context key for translations discovery'
 );
+
+exports.modeKey = Symbol('mode');


### PR DESCRIPTION
Rationale:

In some cases, webpack was attempting to compile the path `../client/[file]` as `/client/[file]` (due to path normalization running [this logic](https://github.com/webpack/memory-fs/blob/master/lib/normalize.js#L33) instead of [this logic](https://github.com/webpack/memory-fs/blob/master/lib/normalize.js#L54))

This PR makes that case work in dev, while avoiding regressions in production