### PR TITLE
Add gql macro from fusion-apollo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-node_modules/
+node_modules/*
 .fusion/
 .nyc_output/
 yarn-error.log

--- a/build/babel-plugins/babel-plugin-gql/index.js
+++ b/build/babel-plugins/babel-plugin-gql/index.js
@@ -1,0 +1,49 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-env node */
+
+const createNamedModuleVisitor = require('../babel-plugin-utils/visit-named-module');
+
+module.exports = gqlPlugin;
+
+function gqlPlugin(babel /*: Object */) {
+  const t = babel.types;
+  const visitor = createNamedModuleVisitor(
+    t,
+    'gql',
+    'fusion-apollo',
+    refsHandler
+  );
+  return {visitor};
+}
+
+function refsHandler(t, context, refs = [], specifierName) {
+  refs.forEach(refPath => {
+    const parentPath = refPath.parentPath;
+    if (!t.isCallExpression(parentPath)) {
+      return;
+    }
+    const args = parentPath.get('arguments');
+    if (args.length !== 1) {
+      throw parentPath.buildCodeFrameError(
+        'gql takes a single string literal argument'
+      );
+    }
+    if (!t.isStringLiteral(args[0])) {
+      throw parentPath.buildCodeFrameError(
+        'gql argument must be a string literal'
+      );
+    }
+    parentPath.replaceWith(
+      t.callExpression(t.identifier('require'), [
+        t.stringLiteral(`__SECRET_GQL_LOADER__!${args[0].node.value}`),
+      ])
+    );
+  });
+}

--- a/build/babel-plugins/babel-plugin-gql/test/fixtures/expected-import-destructuring
+++ b/build/babel-plugins/babel-plugin-gql/test/fixtures/expected-import-destructuring
@@ -1,0 +1,9 @@
+import { gql } from 'fusion-apollo';
+import { gql as gqlOther } from 'gql';
+const path = './test';
+
+require("__SECRET_GQL_LOADER__!./path");
+
+gqlOther(path);
+
+require("__SECRET_GQL_LOADER__!./path");

--- a/build/babel-plugins/babel-plugin-gql/test/fixtures/expected-import-destructuring-as
+++ b/build/babel-plugins/babel-plugin-gql/test/fixtures/expected-import-destructuring-as
@@ -1,0 +1,5 @@
+import { gql as frameworkgql } from 'fusion-apollo';
+import gql from 'gql';
+gql('./path');
+
+require("__SECRET_GQL_LOADER__!./path");

--- a/build/babel-plugins/babel-plugin-gql/test/fixtures/input-import-destructuring
+++ b/build/babel-plugins/babel-plugin-gql/test/fixtures/input-import-destructuring
@@ -1,0 +1,7 @@
+import { gql } from 'fusion-apollo';
+import { gql as gqlOther } from 'gql';
+
+const path = './test';
+gql('./path');
+gqlOther(path);
+gql('./path');

--- a/build/babel-plugins/babel-plugin-gql/test/fixtures/input-import-destructuring-as
+++ b/build/babel-plugins/babel-plugin-gql/test/fixtures/input-import-destructuring-as
@@ -1,0 +1,5 @@
+import { gql as frameworkgql } from 'fusion-apollo';
+import gql from 'gql';
+
+gql('./path');
+frameworkgql('./path');

--- a/build/babel-plugins/babel-plugin-gql/test/fixtures/input-wrong-arg
+++ b/build/babel-plugins/babel-plugin-gql/test/fixtures/input-wrong-arg
@@ -1,0 +1,6 @@
+import { gql as gqlOther } from 'gql';
+import { gql } from 'fusion-apollo';
+
+const path = './test';
+gqlOther('./path');
+gql(path);

--- a/build/babel-plugins/babel-plugin-gql/test/index.js
+++ b/build/babel-plugins/babel-plugin-gql/test/index.js
@@ -1,0 +1,59 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-env node */
+
+const fs = require('fs');
+const test = require('tape');
+const {transformFileSync} = require('@babel/core');
+
+const plugin = require('../');
+
+test('import gql', t => {
+  const output = transformFileSync(
+    __dirname + '/fixtures/input-import-destructuring',
+    {
+      plugins: [plugin],
+    }
+  );
+  const expected = fs
+    .readFileSync(
+      __dirname + '/fixtures/expected-import-destructuring',
+      'utf-8'
+    )
+    .trim();
+  t.equal(output.code, expected, 'replaced correctly');
+  t.end();
+});
+
+test('import gql as', t => {
+  const output = transformFileSync(
+    __dirname + '/fixtures/input-import-destructuring-as',
+    {
+      plugins: [plugin],
+    }
+  );
+  const expected = fs
+    .readFileSync(
+      __dirname + '/fixtures/expected-import-destructuring-as',
+      'utf-8'
+    )
+    .trim();
+  t.equal(output.code, expected, 'replaced correctly');
+  t.end();
+});
+
+test('invalid arguments', t => {
+  function output() {
+    return transformFileSync(__dirname + '/fixtures/input-wrong-arg', {
+      plugins: [plugin],
+    });
+  }
+  t.throws(output, /gql argument must be a string literal/);
+  t.end();
+});

--- a/build/compiler.js
+++ b/build/compiler.js
@@ -29,6 +29,7 @@ const getBabelConfig = require('./get-babel-config.js');
 const LoaderContextProviderPlugin = require('./plugins/loader-context-provider-plugin.js');
 const {
   chunkIdsLoader,
+  gqlLoader,
   fileLoader,
   babelLoader,
   i18nManifestLoader,
@@ -310,6 +311,7 @@ function getConfig({target, env, dir, watch, state}) {
     },
     resolveLoader: {
       alias: {
+        [gqlLoader.alias]: gqlLoader.path,
         [fileLoader.alias]: fileLoader.path,
         [chunkIdsLoader.alias]: chunkIdsLoader.path,
         [syncChunkIdsLoader.alias]: syncChunkIdsLoader.path,

--- a/build/get-babel-config.js
+++ b/build/get-babel-config.js
@@ -135,6 +135,7 @@ function fusionPreset(
 
   return {
     plugins: [
+      require.resolve('./babel-plugins/babel-plugin-gql'),
       require.resolve('./babel-plugins/babel-plugin-asseturl'),
       require.resolve('./babel-plugins/babel-plugin-pure-create-plugin'),
       require.resolve('./babel-plugins/babel-plugin-sync-chunk-ids'),

--- a/build/loaders/gql-loader.js
+++ b/build/loaders/gql-loader.js
@@ -7,7 +7,7 @@
  */
 /* eslint-env node */
 
-module.exports = function fileLoader(content /*: string */) {
+module.exports = function gqlLoader(content /*: string */) {
   // NOTE: For now, we are simply loading queries and schemas as strings.
   // However, we may wish to load a pre-parsed graphql AST, similar to how https://github.com/samsarahq/graphql-loader works.
   const result = `module.exports = ${JSON.stringify(content.toString())};`;

--- a/build/loaders/gql-loader.js
+++ b/build/loaders/gql-loader.js
@@ -1,0 +1,17 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+/* eslint-env node */
+
+module.exports = function fileLoader(content /*: string */) {
+  // NOTE: For now, we are simply loading queries and schemas as strings.
+  // However, we may wish to load a pre-parsed graphql AST, similar to how https://github.com/samsarahq/graphql-loader works.
+  const result = `module.exports = ${JSON.stringify(content.toString())};`;
+  return result;
+};
+
+module.exports.raw = true;

--- a/build/loaders/index.js
+++ b/build/loaders/index.js
@@ -16,6 +16,10 @@ const loaderIndex = {
     alias: '__SECRET_FILE_LOADER__',
     path: require.resolve('./file-loader.js'),
   },
+  gqlLoader: {
+    alias: '__SECRET_GQL_LOADER__',
+    path: require.resolve('./gql-loader.js'),
+  },
   babelLoader: {
     path: require.resolve('./babel-loader.js'),
   },

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -398,8 +398,7 @@ test('`fusion build` works in production with default asset path and supplied RO
 test('`fusion build --production` works with gql', async t => {
   const dir = path.resolve(__dirname, '../fixtures/gql');
   let browser;
-  await 
-  await cmd(`build --dir=${dir} --production`);
+  await await cmd(`build --dir=${dir} --production`);
   const {proc, port} = await start(`--dir=${dir}`, {
     env: Object.assign({}, process.env, {NODE_ENV: 'production'}),
   });

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -411,7 +411,6 @@ test('`fusion build --production` works with gql', async t => {
       expectedSchema,
       'loads schema on server'
     );
-    // Spin up puppeteer to make runtime assertions on assetURLs
     browser = await puppeteer.launch({
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
     });

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -395,6 +395,41 @@ test('`fusion build` works in production with default asset path and supplied RO
   t.end();
 });
 
+test('`fusion build --production` works with gql', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/gql');
+  let browser;
+  await 
+  await cmd(`build --dir=${dir} --production`);
+  const {proc, port} = await start(`--dir=${dir}`, {
+    env: Object.assign({}, process.env, {NODE_ENV: 'production'}),
+  });
+  try {
+    const expectedSchema = fs
+      .readFileSync(path.resolve(dir, 'src/schema.gql'))
+      .toString();
+    t.equal(
+      await request(`http://localhost:${port}/schema`),
+      expectedSchema,
+      'loads schema on server'
+    );
+    // Spin up puppeteer to make runtime assertions on assetURLs
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+    const page = await browser.newPage();
+    await page.goto(`http://localhost:${port}/`, {waitUntil: 'load'});
+    const browserSchema = await page.evaluate(() => {
+      return typeof window !== undefined && window.schema; //eslint-disable-line
+    });
+    t.equal(browserSchema, expectedSchema, 'loads schema in the browser');
+  } catch (e) {
+    t.iferror(e);
+  }
+  await (browser && browser.close());
+  proc.kill();
+  t.end();
+});
+
 test('`fusion build/start with ROUTE_PREFIX and custom routes`', async t => {
   const dir = path.resolve(__dirname, '../fixtures/prefix');
   await cmd(`build --dir=${dir} --production`);

--- a/test/cli/dev.js
+++ b/test/cli/dev.js
@@ -32,6 +32,37 @@ test('`fusion dev` works', async t => {
   t.end();
 });
 
+test('`fusion dev` works with gql', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/gql');
+  let browser;
+  const {proc, port} = await dev(`--dir=${dir}`);
+  try {
+    const expectedSchema = fs
+      .readFileSync(path.resolve(dir, 'src/schema.gql'))
+      .toString();
+    t.equal(
+      await request(`http://localhost:${port}/schema`),
+      expectedSchema,
+      'loads schema on server'
+    );
+    // Spin up puppeteer to make runtime assertions on assetURLs
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+    const page = await browser.newPage();
+    await page.goto(`http://localhost:${port}/`, {waitUntil: 'load'});
+    const browserSchema = await page.evaluate(() => {
+      return typeof window !== undefined && window.schema; //eslint-disable-line
+    });
+    t.equal(browserSchema, expectedSchema, 'loads schema in the browser');
+  } catch (e) {
+    t.iferror(e);
+  }
+  await (browser && browser.close());
+  proc.kill();
+  t.end();
+});
+
 test('`fusion dev` works with assets', async t => {
   const dir = path.resolve(__dirname, '../fixtures/assets');
   const entryPath = path.resolve(

--- a/test/cli/dev.js
+++ b/test/cli/dev.js
@@ -45,7 +45,6 @@ test('`fusion dev` works with gql', async t => {
       expectedSchema,
       'loads schema on server'
     );
-    // Spin up puppeteer to make runtime assertions on assetURLs
     browser = await puppeteer.launch({
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
     });

--- a/test/fixtures/gql/.fusionrc.js
+++ b/test/fixtures/gql/.fusionrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  assumeNoImportSideEffects: true
+};

--- a/test/fixtures/gql/node_modules/fusion-apollo/index.js
+++ b/test/fixtures/gql/node_modules/fusion-apollo/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/fixtures/gql/src/main.js
+++ b/test/fixtures/gql/src/main.js
@@ -1,0 +1,22 @@
+// @flow
+import App from 'fusion-core';
+// $FlowFixMe
+import {gql} from 'fusion-apollo';
+
+const schema = gql('./schema.gql');
+if (__BROWSER__) {
+  window.schema = schema;
+}
+
+export default (async function() {
+  const app = new App('element', el => el);
+  __NODE__ &&
+    app.middleware((ctx, next) => {
+      if (ctx.url === '/schema') {
+        ctx.body = schema;
+      }
+      return next();
+    });
+    
+  return app;
+});

--- a/test/fixtures/gql/src/schema.gql
+++ b/test/fixtures/gql/src/schema.gql
@@ -1,0 +1,7 @@
+type Query {
+  user: User
+}
+
+type User {
+  firstName: String
+}

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,7 @@ require('../build/babel-plugins/babel-plugin-sync-chunk-ids/test');
 require('../build/babel-plugins/babel-plugin-sync-chunk-paths/test');
 require('../build/babel-plugins/babel-plugin-utils/test');
 require('../build/babel-plugins/babel-plugin-transform-tree-shake/test');
+require('../build/babel-plugins/babel-plugin-gql/test');
 
 process.on('unhandledRejection', e => {
   throw e;


### PR DESCRIPTION
Adds support for loading graphql files via gql macro from fusion-apollo.

Example:

```js
import {gql} from 'fusion-apollo';

const query = gql('./query.gql');
const schema = gql('./schema.gql');
```