### PR TITLE
Fix SSR plugin render CSP nonce

### DIFF
--- a/plugins/ssr-plugin.js
+++ b/plugins/ssr-plugin.js
@@ -82,7 +82,7 @@ const SSRBodyTemplate = createPlugin({
       ]);
 
       const criticalChunkScripts = Array.from(allCriticalChunkIds)
-        .map(id => chunkScript(chunks.get(id)))
+        .map(id => chunkScript(ctx, chunks.get(id)))
         .join('');
 
       return [
@@ -102,11 +102,13 @@ const SSRBodyTemplate = createPlugin({
 
 export {SSRBodyTemplate};
 
-function chunkScript(url) {
+function chunkScript(ctx, url) {
   // cross origin is needed to get meaningful errors in window.onerror
   const crossOrigin = url.startsWith('https://')
     ? ' crossorigin="anonymous"'
     : '';
 
-  return `<script defer src="${url}"${crossOrigin}></script>`;
+  return `<script defer src="${url}" nonce="${
+    ctx.nonce
+  }"${crossOrigin}></script>`;
 }


### PR DESCRIPTION
This change fixes a bug where CSP nonces were not included in the generated script tags, which could cause CSP to block the scripts.