### PR TITLE
Fix issue with babel blacklist regexes

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -246,11 +246,11 @@ function getConfig({target, env, dir, watch, state}) {
           test: /\.jsx?$/,
           exclude: [
             // Blacklist mapbox-gl package because of issues with babel-loader and its AMD bundle
-            /node_modules\/mapbox-gl(\/.*?)*$/,
+            /node_modules\/mapbox-gl\//,
             // Blacklist known ES5 packages for build performance
-            /node_modules\/react-dom(\/.*?)*$/,
-            /node_modules\/react(\/.*?)*$/,
-            /node_modules\/core-js(\/.*?)*$/,
+            /node_modules\/react-dom\//,
+            /node_modules\/react\//,
+            /node_modules\/core-js\//,
           ],
           use: [
             {
@@ -497,18 +497,18 @@ function getStatsLogger({dir, logger, envs}) {
   };
 }
 
-/*::
 type CompilerType = {
   on: (type: any, callback: any) => any,
   start: (callback: any) => any,
   getMiddleware: () => any,
   clean: () => any,
 };
-*/
-
-function Compiler(
-  {dir = '.', envs = [], watch = false, logger = console} /*: any */
-) /*: CompilerType */ {
+function Compiler({
+  dir = '.',
+  envs = [],
+  watch = false,
+  logger = console,
+} /*: any */) /*: CompilerType */ {
   const state = {
     clientChunkMetadata: new DeferredState(),
     i18nManifest: new DeferredState(),

--- a/build/compiler.js
+++ b/build/compiler.js
@@ -246,11 +246,11 @@ function getConfig({target, env, dir, watch, state}) {
           test: /\.jsx?$/,
           exclude: [
             // Blacklist mapbox-gl package because of issues with babel-loader and its AMD bundle
-            /node_modules\/mapbox-gl/,
+            /node_modules\/mapbox-gl(\/.*?)*$/,
             // Blacklist known ES5 packages for build performance
-            /node_modules\/react-dom/,
-            /node_modules\/react/,
-            /node_modules\/core-js/,
+            /node_modules\/react-dom(\/.*?)*$/,
+            /node_modules\/react(\/.*?)*$/,
+            /node_modules\/core-js(\/.*?)*$/,
           ],
           use: [
             {

--- a/build/compiler.js
+++ b/build/compiler.js
@@ -497,18 +497,18 @@ function getStatsLogger({dir, logger, envs}) {
   };
 }
 
+/*::
 type CompilerType = {
   on: (type: any, callback: any) => any,
   start: (callback: any) => any,
   getMiddleware: () => any,
   clean: () => any,
 };
-function Compiler({
-  dir = '.',
-  envs = [],
-  watch = false,
-  logger = console,
-} /*: any */) /*: CompilerType */ {
+*/
+
+function Compiler(
+  {dir = '.', envs = [], watch = false, logger = console} /*: any */
+) /*: CompilerType */ {
   const state = {
     clientChunkMetadata: new DeferredState(),
     i18nManifest: new DeferredState(),

--- a/test/compiler/api.js
+++ b/test/compiler/api.js
@@ -211,6 +211,10 @@ test('compiles with babel plugin', async t => {
     dir,
     `.fusion/dist/${envs[0]}/client/client-main.js`
   );
+  const clientVendorPath = path.resolve(
+    dir,
+    `.fusion/dist/${envs[0]}/client/client-vendor.js`
+  );
 
   const compiler = new Compiler({envs, dir});
   await compiler.clean();
@@ -227,18 +231,27 @@ test('compiles with babel plugin', async t => {
   watcher.close();
 
   t.ok(await exists(clientEntryPath), 'Client file gets compiled');
+  t.ok(await exists(clientVendorPath), 'Client vendor file gets compiled');
   t.ok(await exists(serverEntryPath), 'Server file gets compiled');
 
   const clientEntry = await readFile(clientEntryPath, 'utf8');
+  const clientVendorEntry = await readFile(clientVendorPath, 'utf8');
   const serverEntry = await readFile(serverEntryPath, 'utf8');
-
   t.ok(
-    clientEntry.includes('transformed_helloworld_custom_babel'),
+    clientEntry.includes('transformed_custom_babel'),
     'custom plugin applied in client'
   );
   t.ok(
-    serverEntry.includes('transformed_helloworld_custom_babel'),
+    serverEntry.includes('transformed_custom_babel'),
     'custom plugin applied in server'
+  );
+  t.ok(
+    clientVendorEntry.includes('transformed_custom_babel'),
+    'babel plugin runs against node_modules'
+  );
+  t.ok(
+    clientVendorEntry.includes('helloworld'),
+    'babel plugin does not run against blacklist'
   );
 
   t.end();

--- a/test/fixtures/custom-babel/.fusionrc.js
+++ b/test/fixtures/custom-babel/.fusionrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   babel: {
-    plugins: [require.resolve('./plugin.js')]
-  }
+    plugins: [require.resolve('./plugin.js')],
+  },
+  experimentalCompile: true,
 };

--- a/test/fixtures/custom-babel/.gitignore
+++ b/test/fixtures/custom-babel/.gitignore
@@ -1,0 +1,2 @@
+!node_modules/mapbox-gl
+!node_modules/other

--- a/test/fixtures/custom-babel/node_modules/mapbox-gl/index.js
+++ b/test/fixtures/custom-babel/node_modules/mapbox-gl/index.js
@@ -1,0 +1,1 @@
+module.exports = 'helloworld';

--- a/test/fixtures/custom-babel/node_modules/other/index.js
+++ b/test/fixtures/custom-babel/node_modules/other/index.js
@@ -1,0 +1,1 @@
+module.exports = 'helloworld';

--- a/test/fixtures/custom-babel/plugin.js
+++ b/test/fixtures/custom-babel/plugin.js
@@ -2,7 +2,6 @@ module.exports = () => ({
   visitor: {
     StringLiteral(path) {
       if (path.node.value === 'helloworld') {
-        console.log('TRIGGERING...');
         path.node.value = 'transformed_custom_babel';
       }
     },

--- a/test/fixtures/custom-babel/plugin.js
+++ b/test/fixtures/custom-babel/plugin.js
@@ -1,9 +1,10 @@
 module.exports = () => ({
   visitor: {
     StringLiteral(path) {
-      if (path.node.value === "helloworld") {
-        path.node.value = "transformed_helloworld_custom_babel";
+      if (path.node.value === 'helloworld') {
+        console.log('TRIGGERING...');
+        path.node.value = 'transformed_custom_babel';
       }
-    }
-  }
+    },
+  },
 });

--- a/test/fixtures/custom-babel/src/main.js
+++ b/test/fixtures/custom-babel/src/main.js
@@ -1,6 +1,11 @@
 console.log('helloworld');
-import App from 'fusion-core'; 
+import App from 'fusion-core';
 
-export default async function() {
+import test from 'mapbox-gl';
+import other from 'other';
+console.log(test);
+console.log(other);
+
+export default (async function() {
   return new App('el', el => el);
-}
+});


### PR DESCRIPTION
The babel blacklist regexes were matching anything prefixed with
react. This meant we were unknowingly blacklisting all react components
from getting babelified. This updates the regexes and adds a regression test.