### PR TITLE
Update gql loader to use gql tag

### DIFF
--- a/build/loaders/gql-loader.js
+++ b/build/loaders/gql-loader.js
@@ -10,7 +10,10 @@
 module.exports = function gqlLoader(content /*: string */) {
   // NOTE: For now, we are simply loading queries and schemas as strings.
   // However, we may wish to load a pre-parsed graphql AST, similar to how https://github.com/samsarahq/graphql-loader works.
-  const result = `module.exports = ${JSON.stringify(content.toString())};`;
+  const result = `
+  const gql = require('graphql-tag');
+  module.exports = gql(${JSON.stringify(content.toString())});
+  `;
   return result;
 };
 

--- a/test/fixtures/gql/.gitignore
+++ b/test/fixtures/gql/.gitignore
@@ -1,1 +1,2 @@
 !node_modules/fusion-apollo
+!node_modules/graphql-tag

--- a/test/fixtures/gql/node_modules/graphql-tag/index.js
+++ b/test/fixtures/gql/node_modules/graphql-tag/index.js
@@ -1,0 +1,3 @@
+module.exports = function graphqlTag(a) {
+  return a;
+}


### PR DESCRIPTION
This will allow us to treat all graphql code consistently by
always using a parsed ast.