### PR TITLE
Ensure nonces are set for all scripts (including dynamically loaded scripts)

### DIFF
--- a/entries/client-public-path.js
+++ b/entries/client-public-path.js
@@ -1,9 +1,12 @@
 // @flow
 /*::
 declare var __webpack_public_path__: string;
+declare var __webpack_nonce__: string;
 */
 
 import '@babel/polyfill';
 
 // eslint-disable-next-line
 __webpack_public_path__ = window.__FUSION_ASSET_PATH__;
+// eslint-disable-next-line
+__webpack_nonce__ = window.__NONCE__;

--- a/plugins/ssr-plugin.js
+++ b/plugins/ssr-plugin.js
@@ -62,6 +62,7 @@ const SSRBodyTemplate = createPlugin({
         `window.performance && window.performance.mark && window.performance.mark('firstRenderStart');`,
         routePrefix && `__ROUTE_PREFIX__ = ${JSON.stringify(routePrefix)};`,
         `__FUSION_ASSET_PATH__ = ${JSON.stringify(__webpack_public_path__)};`, // consumed in src/entries/client-public-path.js
+        `__NONCE__ = ${JSON.stringify(ctx.nonce)}`, // consumed in src/entries/client-public-path.js
         `</script>`,
       ]
         .filter(Boolean)
@@ -136,6 +137,7 @@ function getLoaderScript(ctx, {legacyUrls, modernUrls}) {
   )} : ${JSON.stringify(modernUrls)}).forEach(function(src) {
     var script = document.createElement('script');
     script.src = src;
+    script.nonce = ${JSON.stringify(ctx.nonce)};
     if (!window.__NOMODULE__) {
       script.type = "module";
     } else {

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -287,6 +287,14 @@ test('`fusion build` app with dynamic imports integration', async t => {
     'all scripts do not have crossorigin attribute'
   );
 
+  t.ok(
+    await page.$$eval('script:not([type="application/json"])', els =>
+      // eslint-disable-next-line
+      els.every(el => el.nonce === window.__NONCE__)
+    ),
+    'all scripts have nonce'
+  );
+
   page.setJavaScriptEnabled(false);
 
   await page.goto(`http://localhost:${port}/`, {waitUntil: 'load'});


### PR DESCRIPTION
Previously, dynamically loaded scripts did not have the appropriate nonce attribute, which could lead to CSP errors.

Also, this ensures the new script loader in https://github.com/fusionjs/fusion-cli/pull/572 sets these as well.