### PR TITLE
Set script nonce attribute rather than property

### DIFF
--- a/plugins/ssr-plugin.js
+++ b/plugins/ssr-plugin.js
@@ -137,7 +137,7 @@ function getLoaderScript(ctx, {legacyUrls, modernUrls}) {
   )} : ${JSON.stringify(modernUrls)}).forEach(function(src) {
     var script = document.createElement('script');
     script.src = src;
-    script.nonce = ${JSON.stringify(ctx.nonce)};
+    script.setAttribute("nonce", ${JSON.stringify(ctx.nonce)});
     if (!window.__NOMODULE__) {
       script.type = "module";
     } else {

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -290,9 +290,9 @@ test('`fusion build` app with dynamic imports integration', async t => {
   t.ok(
     await page.$$eval('script:not([type="application/json"])', els =>
       // eslint-disable-next-line
-      els.every(el => el.nonce === window.__NONCE__)
+      els.every(el => el.getAttribute('nonce') === window.__NONCE__)
     ),
-    'all scripts have nonce'
+    'all scripts have nonce attribute'
   );
 
   page.setJavaScriptEnabled(false);


### PR DESCRIPTION
Fixes an oversight in https://github.com/fusionjs/fusion-cli/pull/576 which was mistakenly setting the element property instead of the attribute.