### PR TITLE
Fix issue with coverage and gql macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .fusion/
 .nyc_output/
 yarn-error.log
+coverage/

--- a/build/babel-plugins/babel-plugin-gql/index.js
+++ b/build/babel-plugins/babel-plugin-gql/index.js
@@ -89,7 +89,7 @@ module.exports = function gqlPlugin(babel /*: Object */, state /*: Object */) {
         );
       } else {
         return t.callExpression(t.identifier('require'), [
-          t.stringLiteral(`__SECRET_GQL_LOADER__!${args[0].node.value}`),
+          t.stringLiteral(`__SECRET_GQL_LOADER__!${args[0].value}`),
         ]);
       }
     }

--- a/build/babel-plugins/babel-plugin-gql/index.js
+++ b/build/babel-plugins/babel-plugin-gql/index.js
@@ -8,12 +8,10 @@
 
 /* eslint-env node */
 
-const _fs = require('fs');
 const path = require('path');
 const createNamedModuleVisitor = require('../babel-plugin-utils/visit-named-module');
 
 module.exports = function gqlPlugin(babel /*: Object */, state /*: Object */) {
-  const fs = state.fs || _fs;
   const inline = state.inline;
   const t = babel.types;
   const visitor = createNamedModuleVisitor(
@@ -27,10 +25,25 @@ module.exports = function gqlPlugin(babel /*: Object */, state /*: Object */) {
   function refsHandler(t, context, refs = [], specifierName) {
     refs.forEach(refPath => {
       const parentPath = refPath.parentPath;
-      if (!t.isCallExpression(parentPath)) {
-        return;
+      if (t.isSequenceExpression(parentPath)) {
+        const callExpression = parentPath.node.expressions.find(
+          n => n.type === 'CallExpression'
+        );
+        const args = callExpression.arguments;
+        validateArgs(args, parentPath);
+        parentPath.node.expressions = parentPath.node.expressions.map(p => {
+          if (p === callExpression) {
+            return getReplacementPath(args);
+          }
+        });
+      } else if (t.isCallExpression(parentPath)) {
+        const args = parentPath.node.arguments;
+        validateArgs(args, parentPath);
+        parentPath.replaceWith(getReplacementPath(args));
       }
-      const args = parentPath.get('arguments');
+    });
+
+    function validateArgs(args, parentPath) {
       if (args.length !== 1) {
         throw parentPath.buildCodeFrameError(
           'gql takes a single string literal argument'
@@ -41,31 +54,44 @@ module.exports = function gqlPlugin(babel /*: Object */, state /*: Object */) {
           'gql argument must be a string literal'
         );
       }
-      if (inline) {
-        const contents = fs
-          .readFileSync(
-            path.resolve(
-              path.dirname(context.file.opts.filename),
-              args[0].node.value
-            )
-          )
-          .toString();
+    }
 
-        parentPath.replaceWith(
-          t.callExpression(
-            t.callExpression(t.identifier('require'), [
-              t.stringLiteral('graphql-tag'),
-            ]),
-            [t.stringLiteral(contents)]
-          )
+    function getReplacementPath(args) {
+      if (inline) {
+        return t.callExpression(
+          t.callExpression(t.identifier('require'), [
+            t.stringLiteral('graphql-tag'),
+          ]),
+          [
+            t.callExpression(
+              t.memberExpression(
+                t.callExpression(
+                  t.memberExpression(
+                    t.callExpression(t.identifier('require'), [
+                      t.stringLiteral('fs'),
+                    ]),
+                    t.identifier('readFileSync')
+                  ),
+                  [
+                    t.stringLiteral(
+                      path.resolve(
+                        path.dirname(context.file.opts.filename),
+                        args[0].value
+                      )
+                    ),
+                  ]
+                ),
+                t.identifier('toString')
+              ),
+              []
+            ),
+          ]
         );
       } else {
-        parentPath.replaceWith(
-          t.callExpression(t.identifier('require'), [
-            t.stringLiteral(`__SECRET_GQL_LOADER__!${args[0].node.value}`),
-          ])
-        );
+        return t.callExpression(t.identifier('require'), [
+          t.stringLiteral(`__SECRET_GQL_LOADER__!${args[0].node.value}`),
+        ]);
       }
-    });
+    }
   }
 };

--- a/build/babel-plugins/babel-plugin-gql/test/fixtures/expected-inline-import-destructuring
+++ b/build/babel-plugins/babel-plugin-gql/test/fixtures/expected-inline-import-destructuring
@@ -1,9 +1,0 @@
-import { gql } from 'fusion-apollo';
-import { gql as gqlOther } from 'gql';
-const path = './test';
-
-require("graphql-tag")(require("fs").readFileSync("/Users/giancarloanemone/dev/fusion-cli/build/babel-plugins/babel-plugin-gql/test/fixtures/file.graphql").toString());
-
-gqlOther(path);
-
-require("graphql-tag")(require("fs").readFileSync("/Users/giancarloanemone/dev/fusion-cli/build/babel-plugins/babel-plugin-gql/test/fixtures/file.graphql").toString());

--- a/build/babel-plugins/babel-plugin-gql/test/fixtures/expected-inline-import-destructuring
+++ b/build/babel-plugins/babel-plugin-gql/test/fixtures/expected-inline-import-destructuring
@@ -2,8 +2,8 @@ import { gql } from 'fusion-apollo';
 import { gql as gqlOther } from 'gql';
 const path = './test';
 
-require("graphql-tag")("type Test {\n  test: String\n}");
+require("graphql-tag")(require("fs").readFileSync("/Users/giancarloanemone/dev/fusion-cli/build/babel-plugins/babel-plugin-gql/test/fixtures/file.graphql").toString());
 
 gqlOther(path);
 
-require("graphql-tag")("type Test {\n  test: String\n}");
+require("graphql-tag")(require("fs").readFileSync("/Users/giancarloanemone/dev/fusion-cli/build/babel-plugins/babel-plugin-gql/test/fixtures/file.graphql").toString());

--- a/build/babel-plugins/babel-plugin-gql/test/index.js
+++ b/build/babel-plugins/babel-plugin-gql/test/index.js
@@ -31,23 +31,6 @@ test('import gql', t => {
   t.end();
 });
 
-test('import gql inline', t => {
-  const output = transformFileSync(
-    __dirname + '/fixtures/input-import-destructuring',
-    {
-      plugins: [[plugin, {inline: true}]],
-    }
-  );
-  const expected = fs
-    .readFileSync(
-      __dirname + '/fixtures/expected-inline-import-destructuring',
-      'utf-8'
-    )
-    .trim();
-  t.equal(output.code, expected, 'replaced correctly');
-  t.end();
-});
-
 test('import gql as', t => {
   const output = transformFileSync(
     __dirname + '/fixtures/input-import-destructuring-as',

--- a/test/cli/test.js
+++ b/test/cli/test.js
@@ -237,6 +237,16 @@ test('`fusion test` coverage', async t => {
   t.end();
 });
 
+test('`fusion test` coverage with gql', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/gql');
+  const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --coverage`;
+
+  const cmd = `require('${runnerPath}').run('node ${runnerPath} ${args}')`;
+  const response = await exec(`node -e "${cmd}"`);
+  t.equal(countTests(response.stderr), 2, 'ran 2 tests');
+  t.end();
+});
+
 test('`fusion test` class properties', async t => {
   const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
   const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --match=class-props`;


### PR DESCRIPTION
This fixes an issue with the inline gql macro and jest coverage
instrumentation. Also updates the plugins to read the graphql files
during test at runtime to resolve potential caching issues.