### PR TITLE
Ignore generated folders for test coverage

### DIFF
--- a/build/jest/base-jest-config.js
+++ b/build/jest/base-jest-config.js
@@ -50,5 +50,6 @@ module.exports = {
     '!**/__integration__/**',
     '!**/node_modules/**',
   ],
+  coveragePathIgnorePatterns: ['src/.*generated.*'],
   testResultsProcessor: require.resolve('./results-processor.js'),
 };

--- a/test/cli/test.js
+++ b/test/cli/test.js
@@ -228,12 +228,18 @@ test('`fusion test` coverage', async t => {
 
   const cmd = `require('${runnerPath}').run('node ${runnerPath} ${args}')`;
   const response = await exec(`node -e "${cmd}"`);
+
   t.equal(countTests(response.stderr), 2, 'ran 2 tests');
 
   // Look for something like coverage
   t.ok(response.stdout.includes('Uncovered Line #s'));
 
+  // This file is outside of src and should not be included in coverage
   t.ok(!response.stdout.includes('should-not-count-for-coverage.js'));
+
+  // Ignores generated files
+  t.ok(!response.stdout.includes('generated-file.js'));
+
   t.end();
 });
 

--- a/test/fixtures/test-jest-app/src/generated/generated-file.js
+++ b/test/fixtures/test-jest-app/src/generated/generated-file.js
@@ -1,0 +1,2 @@
+// @flow
+export default function() {}

--- a/test/fixtures/test-jest-app/src/main.js
+++ b/test/fixtures/test-jest-app/src/main.js
@@ -1,5 +1,8 @@
+// @flow
 import {foo} from './foo.js';
+import noopIgnoredCoverage from './generated/generated-file.js';
 
-export default function () {
+export default function() {
+  noopIgnoredCoverage();
   return foo();
 }


### PR DESCRIPTION
This is a quick solution for ignoring coverage for generated folders while we continue to iterate on #532.