### PR TITLE
Force class transpilation in modern bundle to workaround bugs in Edge

### DIFF
--- a/build/get-babel-config.js
+++ b/build/get-babel-config.js
@@ -96,8 +96,8 @@ module.exports = function getBabelConfig(opts /*: BabelConfigOpts */) {
       esmodules: true,
     };
     envPresetOpts.include = [
+      // Classes must be transpiled due to the following bugs in Edge:
       // https://github.com/Microsoft/ChakraCore/issues/5030
-      'transform-shorthand-properties',
       // https://github.com/Microsoft/ChakraCore/issues/4663
       // https://github.com/babel/babel/issues/8019
       'transform-classes',

--- a/build/get-babel-config.js
+++ b/build/get-babel-config.js
@@ -95,6 +95,13 @@ module.exports = function getBabelConfig(opts /*: BabelConfigOpts */) {
     envPresetOpts.targets = {
       esmodules: true,
     };
+    envPresetOpts.include = [
+      // https://github.com/Microsoft/ChakraCore/issues/5030
+      'transform-shorthand-properties',
+      // https://github.com/Microsoft/ChakraCore/issues/4663
+      // https://github.com/babel/babel/issues/8019
+      'transform-classes',
+    ];
     envPresetOpts.useBuiltIns = 'entry';
   } else if (target === 'browser-legacy') {
     envPresetOpts.modules = false;


### PR DESCRIPTION
Classes need to be transpiled in the modern bundle to work around a couple bugs with Edge with regard to `super()`