### PR TITLE
Add testMatch/testRegex options to `fusion test`

### DIFF
--- a/build/jest/base-jest-config.js
+++ b/build/jest/base-jest-config.js
@@ -8,7 +8,10 @@
 
 /* eslint-env node */
 
-const testFolder = process.env.TEST_FOLDER || '__tests__';
+const matchField = process.env.TEST_REGEX ? 'testRegex' : 'testMatch';
+const matchValue = process.env.TEST_FOLDER
+  ? [`**/${process.env.TEST_FOLDER || '__tests__'}/**/*.js`]
+  : process.env.TEST_REGEX || JSON.parse(process.env.TEST_MATCH);
 
 function getReactVersion() {
   // $FlowFixMe
@@ -43,7 +46,7 @@ module.exports = {
   setupFiles: [require.resolve('./jest-framework-shims.js'), ...reactSetup],
   snapshotSerializers:
     reactSetup.length > 0 ? [require.resolve('enzyme-to-json/serializer')] : [],
-  testMatch: [`**/${testFolder}/**/*.js`],
+  [matchField]: matchValue,
   testURL: 'http://localhost:3000/',
   collectCoverageFrom: [
     'src/**/*.js',

--- a/build/jest/base-jest-config.js
+++ b/build/jest/base-jest-config.js
@@ -11,7 +11,7 @@
 const matchField = process.env.TEST_REGEX ? 'testRegex' : 'testMatch';
 const matchValue = process.env.TEST_FOLDER
   ? [`**/${process.env.TEST_FOLDER || '__tests__'}/**/*.js`]
-  : process.env.TEST_REGEX || JSON.parse(process.env.TEST_MATCH);
+  : process.env.TEST_REGEX || JSON.parse(process.env.TEST_MATCH || '');
 
 function getReactVersion() {
   // $FlowFixMe

--- a/build/test-runtime.js
+++ b/build/test-runtime.js
@@ -20,7 +20,9 @@ module.exports.TestAppRuntime = function(
     debug = false,
     match,
     env,
-    testFolder,
+    testFolder, // deprecated
+    testMatch,
+    testRegex,
     updateSnapshot,
     configPath,
     jestArgs = {},
@@ -74,10 +76,11 @@ module.exports.TestAppRuntime = function(
     const spawnProc = () => {
       return new Promise((resolve, reject) => {
         const args = getArgs();
-
         const procEnv = {
           JEST_ENV: env,
-          TEST_FOLDER: testFolder,
+          TEST_FOLDER: testFolder, // deprecated
+          TEST_MATCH: testMatch,
+          TEST_REGEX: testRegex,
         };
         const proc = spawn('node', args, {
           cwd: rootDir,

--- a/commands/index.js
+++ b/commands/index.js
@@ -146,8 +146,21 @@ module.exports = {
       },
       testFolder: {
         type: 'string',
-        default: '__tests__',
-        describe: 'Which folder to look for tests in.',
+        default: '',
+        describe:
+          'Which folder to look for tests in. Deprecated, use testMatch or testRegex instead.',
+      },
+      testMatch: {
+        type: 'string',
+        default: '["**/__tests__/**/*.js"]',
+        describe:
+          'Which folder to look for tests in. A JSON array of glob patterns.',
+      },
+      testRegex: {
+        type: 'string',
+        default: '',
+        describe:
+          'Which folder to look for tests in. A JSON array of regexp strings.',
       },
       configPath: {
         type: 'string',

--- a/commands/test.js
+++ b/commands/test.js
@@ -17,7 +17,9 @@ exports.run = async function(
     debug,
     match,
     env,
-    testFolder,
+    testFolder, // deprecated
+    testMatch,
+    testRegex,
     configPath,
     // Allow snapshots to be updated using `-u` as well as --updateSnapshot.
     // We don't document this argument, but since jest output automatically
@@ -42,7 +44,9 @@ exports.run = async function(
     debug,
     match,
     env,
-    testFolder,
+    testFolder, // deprecated
+    testMatch,
+    testRegex,
     configPath,
     jestArgs,
   });

--- a/test/cli/test.js
+++ b/test/cli/test.js
@@ -105,6 +105,28 @@ test('`fusion test --testFolder=integration` runs correct tests', async t => {
   t.end();
 });
 
+test('`fusion test --testMatch=["**/__foo__/**.*js"]` runs correct tests', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
+  const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --env=node --testMatch=[\\"**/__foo__/**/*.js\\"]`;
+
+  const cmd = `require('${runnerPath}').run('node ${runnerPath} ${args}')`;
+  const response = await exec(`node -e "${cmd}"`);
+  t.equal(countTests(response.stderr), 1, 'ran 1 test');
+
+  t.end();
+});
+
+test('`fusion test --testRegex=/__foo__/.*` runs correct tests', async t => {
+  const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
+  const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --env=node --testRegex=.*/__foo__/.*`;
+
+  const cmd = `require('${runnerPath}').run('node ${runnerPath} ${args}')`;
+  const response = await exec(`node -e "${cmd}"`);
+  t.equal(countTests(response.stderr), 1, 'ran 1 test');
+
+  t.end();
+});
+
 test('`fusion test` snapshotting', async t => {
   const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
   const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --match=snapshot-no-match`;

--- a/test/fixtures/test-jest-app/src/__foo__/passes.js
+++ b/test/fixtures/test-jest-app/src/__foo__/passes.js
@@ -1,0 +1,4 @@
+// @flow
+test('Everything is ok', () => {
+  expect(true).toBe(true);
+});

--- a/test/fixtures/test-jest-app/src/__foo__/passes.js
+++ b/test/fixtures/test-jest-app/src/__foo__/passes.js
@@ -1,4 +1,6 @@
 // @flow
+//$FlowFixMe
 test('Everything is ok', () => {
+  //$FlowFixMe
   expect(true).toBe(true);
 });


### PR DESCRIPTION
Fixes https://github.com/fusionjs/fusion-cli/issues/533

Some projects at Uber have large existing test suites structured differently than the-jest-way(tm). This PR allows those users to configure their project to find tests where they currently exist in order to avoid expensive refactors.

This also helps pave the road for monorepo configuration