### PR TITLE
Fix SVG optimization so it doesn't remove symbols for external `<use>` tags

### DIFF
--- a/lib/compression/svgo-webpack-plugin.js
+++ b/lib/compression/svgo-webpack-plugin.js
@@ -19,7 +19,11 @@ module.exports = new CompressionPlugin({
   algorithm: function(buf, options, callback) {
     imagemin
       .buffer(buf, {
-        plugins: [svgo()],
+        plugins: [
+          svgo({
+            plugins: [{removeUselessDefs: false}, {cleanupIDs: false}],
+          }),
+        ],
       })
       .then(function(result) {
         callback(null, result);

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -654,6 +654,11 @@ test('`fusion build` compresses assets for production', async t => {
       ),
       'svg works'
     );
+    t.ok(
+      fs
+        .readFileSync(path.resolve(dir, 'src/assets/SVG_logo.svg'), 'utf8')
+        .includes('shouldNotBeRemoved')
+    );
   });
   t.end();
 });

--- a/test/fixtures/compress-assets/src/assets/SVG_logo.svg
+++ b/test/fixtures/compress-assets/src/assets/SVG_logo.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100%" height="100%" viewBox="0 0 100 100">
 
   <title>SVG Logo</title>
-
+  <symbol id="shouldNotBeRemoved"></symbol>
   <a xlink:href="http://www.w3.org/Graphics/SVG/" target="_parent"
      xlink:title="W3C SVG Working Group home page">
 
@@ -169,7 +169,7 @@
                H 10.30
                Q  5.30,95.00  5.30,90.00 Z"/>
 
-        <path 
+        <path
             id="shine"
             fill="#3F3F3F"
             d="M  14.657,54.211
@@ -227,7 +227,7 @@
                         49.920,76.342
                         54.755,53.005"/>
 
-         <path 
+         <path
             id="G"
             fill="#FFFFFF"
             stroke="#000000"


### PR DESCRIPTION
Rationale: we want users to be able to take an SVG file such as this:

```
<svg xmlns="http://www.w3.org/2000/svg">
  <symbol id="mything" viewBox="0 0 24 24">
    <path d="somepath" fill="var(--thing-color)"/>
  </symbol>
</svg>
```
 
And use it like this:

```
const mything = `${assetUrl('../static/mything.svg')}#mything`;

// JSX
<svg width="24" height="24" style={{'--thing-color': '#00f'}}>
  <use xlinkHref={mything} />
</svg>
```

This PR disables optimizations that prevents this use case from working.