### PR TITLE
Improve DX of testMatch

### DIFF
--- a/build/jest/base-jest-config.js
+++ b/build/jest/base-jest-config.js
@@ -11,7 +11,8 @@
 const matchField = process.env.TEST_REGEX ? 'testRegex' : 'testMatch';
 const matchValue = process.env.TEST_FOLDER
   ? [`**/${process.env.TEST_FOLDER || '__tests__'}/**/*.js`]
-  : process.env.TEST_REGEX || JSON.parse(process.env.TEST_MATCH || '');
+  : process.env.TEST_REGEX ||
+    (process.env.TEST_MATCH || '**/__tests__/**/*.js').split(',');
 
 function getReactVersion() {
   // $FlowFixMe

--- a/commands/index.js
+++ b/commands/index.js
@@ -152,7 +152,7 @@ module.exports = {
       },
       testMatch: {
         type: 'string',
-        default: '["**/__tests__/**/*.js"]',
+        default: '',
         describe:
           'Which folder to look for tests in. A JSON array of glob patterns.',
       },

--- a/commands/test.js
+++ b/commands/test.js
@@ -39,6 +39,16 @@ exports.run = async function(
     }
   });
 
+  if (
+    (testFolder !== '' && testMatch !== '') ||
+    (testFolder !== '' && testRegex !== '') ||
+    (testMatch !== '' && testRegex !== '')
+  ) {
+    throw new Error(
+      'Only one of testMatch, testRegex and testFolder can be defined at one time'
+    );
+  }
+
   const testRuntime = new TestAppRuntime({
     dir,
     debug,

--- a/test/cli/test.js
+++ b/test/cli/test.js
@@ -107,7 +107,7 @@ test('`fusion test --testFolder=integration` runs correct tests', async t => {
 
 test('`fusion test --testMatch=["**/__foo__/**.*js"]` runs correct tests', async t => {
   const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
-  const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --env=node --testMatch=[\\"**/__foo__/**/*.js\\"]`;
+  const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --env=node --testMatch=**/__foo__/**/*.js`;
 
   const cmd = `require('${runnerPath}').run('node ${runnerPath} ${args}')`;
   const response = await exec(`node -e "${cmd}"`);
@@ -123,6 +123,42 @@ test('`fusion test --testRegex=/__foo__/.*` runs correct tests', async t => {
   const cmd = `require('${runnerPath}').run('node ${runnerPath} ${args}')`;
   const response = await exec(`node -e "${cmd}"`);
   t.equal(countTests(response.stderr), 1, 'ran 1 test');
+
+  t.end();
+});
+
+test('`fusion test --testRegex and --testMatch cannot occur at same time', async t => {
+  t.plan(1);
+
+  const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
+  const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --env=node --testMatch=**/__foo__/**/*.js --testRegex=.*/__foo__/.*`;
+
+  const cmd = `require('${runnerPath}').run('node ${runnerPath} ${args}')`;
+  await exec(`node -e "${cmd}"`).catch(e => t.pass());
+
+  t.end();
+});
+
+test('`fusion test --testFolder and --testMatch cannot occur at same time', async t => {
+  t.plan(1);
+
+  const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
+  const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --env=node --testMatch=**/__foo__/**/*.js --testFolder=__foo__`;
+
+  const cmd = `require('${runnerPath}').run('node ${runnerPath} ${args}')`;
+  await exec(`node -e "${cmd}"`).catch(e => t.pass());
+
+  t.end();
+});
+
+test('`fusion test --testFolder and --testRegex cannot occur at same time', async t => {
+  t.plan(1);
+
+  const dir = path.resolve(__dirname, '../fixtures/test-jest-app');
+  const args = `test --dir=${dir} --configPath=../../../build/jest/jest-config.js --env=node --testRegex=.*/__foo__/.* --testFolder=__foo__`;
+
+  const cmd = `require('${runnerPath}').run('node ${runnerPath} ${args}')`;
+  await exec(`node -e "${cmd}"`).catch(e => t.pass());
 
   t.end();
 });


### PR DESCRIPTION
- throw if multiple redundant configs are set (testMatch/testRegex/testFolder)
- change testMatch to take comma-separated list, vs JSON