### PR TITLE
Fix race condition in script loading

### DIFF
--- a/plugins/ssr-plugin.js
+++ b/plugins/ssr-plugin.js
@@ -135,6 +135,7 @@ function getLoaderScript(ctx, {legacyUrls, modernUrls}) {
   )} : ${JSON.stringify(modernUrls)}).forEach(function(src) {
     var script = document.createElement('script');
     script.src = src;
+    script.async = false;
     script.setAttribute("nonce", ${JSON.stringify(ctx.nonce)});
     script.defer = true;
     if (script.src.indexOf(window.location.origin + '/') !== 0) {

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -273,6 +273,14 @@ test('`fusion build` app with dynamic imports integration', async t => {
 
   t.equal(await page.$$eval('script', els => els.length), BASE_COUNT);
 
+  // Async can causes race conditions as scripts may be executed before DOM is fully parsed.
+  t.ok(
+    await page.$$eval('script:not([type="application/json"])', els =>
+      els.every(el => el.async === false)
+    ),
+    'all scripts not be async'
+  );
+
   await page.click('#split-route-link');
   t.equal(
     await page.$$eval('script', els => els.length),


### PR DESCRIPTION
Because dynamically inserted scripts are implicitly async by default (which takes precedence over defer), a race condition was introduced where bundle scripts might be executed early and/or out-of-order.

This change forces these scripts to be explicitly not async, so the defer attribute will work.