### PR TITLE
Switch to parser-inserted scripts, fix script preloading for legacy bundles

### DIFF
--- a/build/get-webpack-config.js
+++ b/build/get-webpack-config.js
@@ -454,7 +454,7 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
       new InstrumentedImportDependencyTemplatePlugin(
         runtime !== 'client'
           ? // Server
-            state.clientChunkMetadata
+            state.mergedClientChunkMetadata
           : /**
              * Client
              * Don't wait for the client manifest on the client.


### PR DESCRIPTION
**Summary**
- Fixes script preloading in legacy browsers
- Replaces dynamic script loading with scripts in markup to ensure the scripts are marked as parser-inserted. Not all browsers respect `defer` attributes for scripts that are not marked as parser-inserted. This caused problems in FF/Edge. https://html.spec.whatwg.org/multipage/scripting.html

  - Replace runtime Edge UA check with server-side UA check (to avoid bugs with native classes)
  - Replace runtime `nomodule` support check with server-side UA check for Safari 10.1 (to prevent double script download/execution)