### PR TITLE
Remove nomodule attributes when only serving legacy scripts

### DIFF
--- a/plugins/ssr-plugin.js
+++ b/plugins/ssr-plugin.js
@@ -145,11 +145,12 @@ const SSRBodyTemplate = createPlugin({
       // Safari 10.1 does not respect nomodule attributes
       if (forceLegacyOnly || !isSafari10_1) {
         for (let url of legacyUrls) {
+          const nomoduleAttr = forceLegacyOnly ? '' : ' nomodule';
           const crossoriginAttr = url.startsWith(__webpack_public_path__)
             ? ''
             : ' crossorigin="anonymous"';
           criticalChunkScripts.push(
-            `<script nomodule defer src="${url}" nonce="${
+            `<script${nomoduleAttr} defer src="${url}" nonce="${
               ctx.nonce
             }"${crossoriginAttr}></script>`
           );


### PR DESCRIPTION
When a CDN is not used, module scripts are not served to Safari. Safari 10.1 will ignore these, but newer versions will respect them.