### PR TITLE
Release v1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fusion-cli",
-  "version": "1.13.0-beta.14",
+  "version": "1.13.0",
   "description": "CLI",
   "repository": "fusionjs/fusion-cli",
   "bin": {


### PR DESCRIPTION
- Fix runtime chunk in legacy bundles ([#618](https://github.com/fusionjs/fusion-cli/pull/618))
- Remove nomodule attributes when only serving legacy scripts ([#616](https://github.com/fusionjs/fusion-cli/pull/616))
- Ensure credentials are sent for same-origin module chunks ([#614](https://github.com/fusionjs/fusion-cli/pull/614))
- Switch to parser-inserted scripts, fix script preloading for legacy bundles ([#612](https://github.com/fusionjs/fusion-cli/pull/612))
- Fix EADDRINUSE error in dev ([#611](https://github.com/fusionjs/fusion-cli/pull/611))
- Improve DX of testMatch ([#604](https://github.com/fusionjs/fusion-cli/pull/604))
- Fix race condition in script loading ([#605](https://github.com/fusionjs/fusion-cli/pull/605))
- Serve legacy bundle to Edge, use native classes in modern bundle ([#601](https://github.com/fusionjs/fusion-cli/pull/601))
- Add testMatch/testRegex options to `fusion test` ([#596](https://github.com/fusionjs/fusion-cli/pull/596))
- Fix SVG optimization so it doesn't remove symbols for external `<use>` tags ([#600](https://github.com/fusionjs/fusion-cli/pull/600))
- Fix server-side only assets in development ([#597](https://github.com/fusionjs/fusion-cli/pull/597))
- Force class transpilation in modern bundle to workaround bugs in Edge ([#593](https://github.com/fusionjs/fusion-cli/pull/593))
- Fix issue with coverage and gql macro ([#588](https://github.com/fusionjs/fusion-cli/pull/588))
- Update gql plugin to work in tests ([#586](https://github.com/fusionjs/fusion-cli/pull/586))
- Update gql loader to use gql tag ([#573](https://github.com/fusionjs/fusion-cli/pull/573))
- Load modern bundles as regular scripts ([#582](https://github.com/fusionjs/fusion-cli/pull/582))
- Set script nonce attribute rather than property ([#579](https://github.com/fusionjs/fusion-cli/pull/579))
- Ensure nonces are set for all scripts (including dynamically loaded scripts) ([#576](https://github.com/fusionjs/fusion-cli/pull/576))