### PR TITLE
do not override default webpack node polyfills settings

### DIFF
--- a/build/get-webpack-config.js
+++ b/build/get-webpack-config.js
@@ -580,12 +580,6 @@ if (process.env.NODE_ENV && process.env.NODE_ENV !== '${env}') {
 function getNodeConfig(runtime) {
   const emptyForWeb = runtime === 'client' ? 'empty' : false;
   return {
-    // Polyfilling process involves lots of cruft. Better to explicitly inline env value statically
-    process: false,
-    // We definitely don't want automatic Buffer polyfills. This should be explicit and in userland code
-    Buffer: false,
-    // We definitely don't want automatic setImmediate polyfills. This should be explicit and in userland code
-    setImmediate: false,
     // We want these to resolve to the original file source location, not the compiled location
     // in the future, we may want to consider using `import.meta`
     __filename: true,


### PR DESCRIPTION
Webpack does not include polyfills for Buffer and Process unless it encounters their references. 

Explicitly defaulting them to `false` makes things difficult for users whose deps and subdeps depend on default webpack's polyfilling. 


