### PR TITLE
Replace module scripts with useragent checks

### DIFF
--- a/build/get-webpack-config.js
+++ b/build/get-webpack-config.js
@@ -282,6 +282,7 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
                       // Explictly only transpile user source code as well as fusion-cli entry files
                       path.join(dir, 'src'),
                       /fusion-cli\/entries/,
+                      /fusion-cli\/plugins/,
                     ],
                     ...babelOverrides,
                   },
@@ -318,6 +319,7 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
                       // Explictly only transpile user source code as well as fusion-cli entry files
                       path.join(dir, 'src'),
                       /fusion-cli\/entries/,
+                      /fusion-cli\/plugins/,
                     ],
                     ...babelOverrides,
                   },
@@ -354,6 +356,7 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
                       // Explictly only transpile user source code as well as fusion-cli entry files
                       path.join(dir, 'src'),
                       /fusion-cli\/entries/,
+                      /fusion-cli\/plugins/,
                     ],
                     ...legacyBabelOverrides,
                   },

--- a/test/cli/build.js
+++ b/test/cli/build.js
@@ -161,12 +161,12 @@ test('`fusion build` works in production with a CDN_URL', async t => {
   });
 
   t.ok(
-    res.includes('https://cdn.com/test/client-main'),
-    'includes a reference to client-main'
+    res.includes('https://cdn.com/test/client-legacy-main'),
+    'includes a reference to client-legacy-main'
   );
   t.ok(
-    res.includes('https://cdn.com/test/client-vendor'),
-    'includes a reference to client-vendor'
+    res.includes('https://cdn.com/test/client-legacy-vendor'),
+    'includes a reference to client-legacy-vendor'
   );
   proc.kill();
   t.end();
@@ -298,18 +298,14 @@ test('`fusion build` app with dynamic imports integration', async t => {
   const BASE_COUNT = SYNC_CHUNK_COUNT + ROUTE_INDEPENDENT_ASYNC_CHUNK_COUNT;
 
   t.equal(
-    await page.$$eval('link[rel="modulepreload"]', els => els.length),
+    await page.$$eval('link[rel="preload"]', els => els.length),
     BASE_COUNT
   );
   t.equal(
     await page.$$eval(
-      'script[src]:not([type="module"]):not([type="application/json"])',
+      'script[src]:not([type="application/json"])',
       els => els.length
     ),
-    BASE_COUNT
-  );
-  t.equal(
-    await page.$$eval('script[src][type="module"]', els => els.length),
     BASE_COUNT
   );
 
@@ -324,7 +320,7 @@ test('`fusion build` app with dynamic imports integration', async t => {
   await page.click('#split-route-link');
   t.equal(
     await page.$$eval(
-      'script[src]:not([type="module"]):not([type="application/json"])',
+      'script[src]:not([type="application/json"])',
       els => els.length
     ),
     BASE_COUNT + 1,
@@ -332,9 +328,8 @@ test('`fusion build` app with dynamic imports integration', async t => {
   );
 
   t.ok(
-    await page.$$eval(
-      'script[src]:not([type="application/json"]):not([type="module"])',
-      els => els.every(el => el.crossOrigin === null)
+    await page.$$eval('script[src]:not([type="application/json"])', els =>
+      els.every(el => el.crossOrigin === null)
     ),
     'non-module scripts do not have crossorigin attribute'
   );
@@ -356,18 +351,14 @@ test('`fusion build` app with dynamic imports integration', async t => {
   await page.goto(`http://localhost:${port}/split-route`);
 
   t.equal(
-    await page.$$eval('link[rel="modulepreload"]', els => els.length),
+    await page.$$eval('link[rel="preload"]', els => els.length),
     BASE_COUNT + 1
   );
   t.equal(
     await page.$$eval(
-      'script[src]:not([type="module"]):not([type="application/json"])',
+      'script[src]:not([type="application/json"])',
       els => els.length
     ),
-    BASE_COUNT + 1
-  );
-  t.equal(
-    await page.$$eval('script[src][type="module"]', els => els.length),
     BASE_COUNT + 1
   );
 
@@ -414,7 +405,7 @@ test('`fusion build` app with Safari user agent and same-origin', async t => {
 
   t.equal(
     await page.$$eval(
-      'script[src]:not([type="module"]):not([type="application/json"])',
+      'script[src]:not([type="application/json"])',
       els => els.length
     ),
     BASE_COUNT
@@ -431,7 +422,7 @@ test('`fusion build` app with Safari user agent and same-origin', async t => {
   await page.click('#split-route-link');
   t.equal(
     await page.$$eval(
-      'script[src]:not([type="module"]):not([type="application/json"])',
+      'script[src]:not([type="application/json"])',
       els => els.length
     ),
     BASE_COUNT + 1,
@@ -439,9 +430,8 @@ test('`fusion build` app with Safari user agent and same-origin', async t => {
   );
 
   t.ok(
-    await page.$$eval(
-      'script[src]:not([type="application/json"]):not([type="module"])',
-      els => els.every(el => el.crossOrigin === null)
+    await page.$$eval('script[src]:not([type="application/json"])', els =>
+      els.every(el => el.crossOrigin === null)
     ),
     'non-module scripts do not have crossorigin attribute'
   );
@@ -548,12 +538,12 @@ test('`fusion build` works in production with default asset path and supplied RO
     env: Object.assign({}, process.env, {ROUTE_PREFIX: '/test-prefix'}),
   });
   t.ok(
-    res.includes('/test-prefix/_static/client-main'),
-    'includes a reference to client-main'
+    res.includes('/test-prefix/_static/client-legacy-main'),
+    'includes a reference to client-legacy-main'
   );
   t.ok(
-    res.includes('/test-prefix/_static/client-vendor'),
-    'includes a reference to client-vendor'
+    res.includes('/test-prefix/_static/client-legacy-vendor'),
+    'includes a reference to client-legacy-vendor'
   );
   proc.kill();
   t.end();
@@ -700,12 +690,12 @@ test('`fusion build` works in production', async t => {
   );
   const {res, proc} = await start(`--dir=${dir}`);
   t.ok(
-    res.includes('/_static/client-main'),
-    'includes a reference to client-main'
+    res.includes('/_static/client-legacy-main'),
+    'includes a reference to client-legacy-main'
   );
   t.ok(
-    res.includes('/_static/client-vendor'),
-    'includes a reference to client-vendor'
+    res.includes('/_static/client-legacy-vendor'),
+    'includes a reference to client-legacy-vendor'
   );
 
   clientFiles.forEach(file => {


### PR DESCRIPTION
- Solves issues with Safari and same-origin credentials w/ module scripts:  https://bugs.webkit.org/show_bug.cgi?id=171550
- Fixes regression if bundles include code that must be run in non-strict mode(modules are always strict mode).

Fixes https://github.com/fusionjs/fusion-cli/issues/627
Fixes https://github.com/fusionjs/fusion-cli/issues/622