### PR TITLE
Collect translations from translate function

### DIFF
--- a/build/babel-plugins/babel-plugin-i18n/test/fixtures/destructured
+++ b/build/babel-plugins/babel-plugin-i18n/test/fixtures/destructured
@@ -3,7 +3,8 @@ import {withTranslations} from 'fusion-plugin-i18n-react';
 
 class MyClass extends React.Component {
   render() {
-    return this.props.translate('some.translation');
+    const {translate} = this.props;
+    return translate('some.translation');
   }
 }
 

--- a/build/babel-plugins/babel-plugin-i18n/test/fixtures/mixed
+++ b/build/babel-plugins/babel-plugin-i18n/test/fixtures/mixed
@@ -1,0 +1,10 @@
+import React from 'react';
+import {withTranslations} from 'fusion-plugin-i18n-react';
+
+class MyClass extends React.Component {
+  render() {
+    return this.props.translate('prop.translation')
+  }
+}
+
+export default withTranslations(['array.translation'])(MyClass);

--- a/build/babel-plugins/babel-plugin-i18n/test/fixtures/mixed
+++ b/build/babel-plugins/babel-plugin-i18n/test/fixtures/mixed
@@ -1,9 +1,21 @@
 import React from 'react';
-import {withTranslations} from 'fusion-plugin-i18n-react';
+import {withTranslations, Translate} from 'fusion-plugin-i18n-react';
 
 class MyClass extends React.Component {
+  renderSubFn({translate}) {
+    return (
+      <div>{translate('subfn.translation')}</div>
+    )
+  }
   render() {
-    return this.props.translate('prop.translation');
+    const {translate} = this.props;
+    return (
+      <div>
+        {this.props.translate('prop.translation')}
+        {this.renderSubFn({translate})}
+        <Translate id="jsx.translation" />
+      </div>
+    );
   }
 }
 

--- a/build/babel-plugins/babel-plugin-i18n/test/fixtures/mixed
+++ b/build/babel-plugins/babel-plugin-i18n/test/fixtures/mixed
@@ -3,7 +3,7 @@ import {withTranslations} from 'fusion-plugin-i18n-react';
 
 class MyClass extends React.Component {
   render() {
-    return this.props.translate('prop.translation')
+    return this.props.translate('prop.translation');
   }
 }
 

--- a/build/babel-plugins/babel-plugin-i18n/test/fixtures/non-string-arg
+++ b/build/babel-plugins/babel-plugin-i18n/test/fixtures/non-string-arg
@@ -3,7 +3,9 @@ import {withTranslations} from 'fusion-plugin-i18n-react';
 
 class MyClass extends React.Component {
   render() {
-    return this.props.translate('some.translation');
+    const {translate} = this.props;
+    const key = 'some.translation';
+    return translate(key);
   }
 }
 

--- a/build/babel-plugins/babel-plugin-i18n/test/fixtures/string-array
+++ b/build/babel-plugins/babel-plugin-i18n/test/fixtures/string-array
@@ -1,0 +1,10 @@
+import React from 'react';
+import {withTranslations} from 'fusion-plugin-i18n-react';
+
+class MyClass extends React.Component {
+  render() {
+    return null;
+  }
+}
+
+export default withTranslations(['some.translation'])(MyClass);

--- a/build/babel-plugins/babel-plugin-i18n/test/fixtures/translate-prop
+++ b/build/babel-plugins/babel-plugin-i18n/test/fixtures/translate-prop
@@ -1,0 +1,10 @@
+import React from 'react';
+import {withTranslations} from 'fusion-plugin-i18n-react';
+
+class MyClass extends React.Component {
+  render() {
+    return this.props.translate('some.translation')
+  }
+}
+
+export default withTranslations([])(MyClass);

--- a/build/babel-plugins/babel-plugin-i18n/test/index.js
+++ b/build/babel-plugins/babel-plugin-i18n/test/index.js
@@ -8,5 +8,54 @@
 
 /* eslint-env node */
 
-// This babel plugin only produces side effects
-// Instead, this plugin is integration tested
+const fs = require('fs');
+const test = require('tape');
+const {transformFileSync} = require('@babel/core');
+
+const plugin = require('../');
+
+test('withTranslations string array', t => {
+  const translationIds = new Set();
+  const output = transformFileSync(
+    __dirname + '/fixtures/string-array',
+    {
+      plugins: [[plugin, {translationIds}]],
+    }
+  );
+  const expected = new Set([
+    'some.translation'
+  ]);
+  t.deepEqual(translationIds, expected, 'parsed string list');
+  t.end();
+});
+
+test('translate prop', t => {
+  const translationIds = new Set();
+  const output = transformFileSync(
+    __dirname + '/fixtures/translate-prop',
+    {
+      plugins: [[plugin, {translationIds}]],
+    }
+  );
+  const expected = new Set([
+    'some.translation'
+  ]);
+  t.deepEqual(translationIds, expected, 'parsed string list');
+  t.end();
+});
+
+test('mixed', t => {
+  const translationIds = new Set();
+  const output = transformFileSync(
+    __dirname + '/fixtures/mixed',
+    {
+      plugins: [[plugin, {translationIds}]],
+    }
+  );
+  const expected = new Set([
+    'prop.translation',
+    'array.translation',
+  ]);
+  t.deepEqual(translationIds, expected, 'parsed string list');
+  t.end();
+});

--- a/build/babel-plugins/babel-plugin-i18n/test/index.js
+++ b/build/babel-plugins/babel-plugin-i18n/test/index.js
@@ -14,20 +14,20 @@ const {transformFileSync} = require('@babel/core');
 
 const plugin = require('../');
 
-test('withTranslations string array', t => {
-  const translationIds = new Set();
-  const output = transformFileSync(
-    __dirname + '/fixtures/string-array',
-    {
-      plugins: [[plugin, {translationIds}]],
-    }
-  );
-  const expected = new Set([
-    'some.translation'
-  ]);
-  t.deepEqual(translationIds, expected, 'parsed string list');
-  t.end();
-});
+ test('withTranslations string array', t => {
+   const translationIds = new Set();
+   const output = transformFileSync(
+     __dirname + '/fixtures/string-array',
+     {
+       plugins: [[plugin, {translationIds}]],
+     }
+   );
+   const expected = new Set([
+     'some.translation'
+   ]);
+   t.deepEqual(translationIds, expected, 'parsed string list');
+   t.end();
+ });
 
 test('translate prop', t => {
   const translationIds = new Set();
@@ -44,18 +44,47 @@ test('translate prop', t => {
   t.end();
 });
 
-test('mixed', t => {
+test('translate prop destructured', t => {
   const translationIds = new Set();
   const output = transformFileSync(
-    __dirname + '/fixtures/mixed',
+    __dirname + '/fixtures/destructured',
     {
       plugins: [[plugin, {translationIds}]],
     }
   );
   const expected = new Set([
-    'prop.translation',
-    'array.translation',
+    'some.translation'
   ]);
   t.deepEqual(translationIds, expected, 'parsed string list');
+  t.end();
+});
+
+ test('mixed', t => {
+   const translationIds = new Set();
+   const output = transformFileSync(
+     __dirname + '/fixtures/mixed',
+     {
+       plugins: [[plugin, {translationIds}]],
+     }
+   );
+   const expected = new Set([
+     'prop.translation',
+     'array.translation',
+   ]);
+   t.deepEqual(translationIds, expected, 'parsed string list');
+   t.end();
+ });
+
+ test('non-string arg', t => {
+  const translationIds = new Set();
+  function output () {
+    transformFileSync(
+      __dirname + '/fixtures/non-string-arg',
+      {
+        plugins: [[plugin, {translationIds}]],
+      }
+    );
+  };
+  t.throws(output, /string literal/);
   t.end();
 });

--- a/build/babel-plugins/babel-plugin-i18n/test/index.js
+++ b/build/babel-plugins/babel-plugin-i18n/test/index.js
@@ -14,33 +14,33 @@ const {transformFileSync} = require('@babel/core');
 
 const plugin = require('../');
 
- test('withTranslations string array', t => {
-   const translationIds = new Set();
-   const output = transformFileSync(
-     __dirname + '/fixtures/string-array',
-     {
-       plugins: [[plugin, {translationIds}]],
-     }
-   );
-   const expected = new Set([
-     'some.translation'
-   ]);
-   t.deepEqual(translationIds, expected, 'parsed string list');
-   t.end();
- });
+test('withTranslations string array', t => {
+  const translationIds = new Set();
+  const output = transformFileSync(
+    __dirname + '/fixtures/string-array',
+    {
+      plugins: ['@babel/transform-react-jsx', [plugin, {translationIds}]],
+    }
+  );
+  const expected = [
+    'some.translation'
+  ];
+  t.deepEqual(Array.from(translationIds), expected);
+  t.end();
+});
 
 test('translate prop', t => {
   const translationIds = new Set();
   const output = transformFileSync(
     __dirname + '/fixtures/translate-prop',
     {
-      plugins: [[plugin, {translationIds}]],
+      plugins: ['@babel/transform-react-jsx', [plugin, {translationIds}]],
     }
   );
-  const expected = new Set([
+  const expected = [
     'some.translation'
-  ]);
-  t.deepEqual(translationIds, expected, 'parsed string list');
+  ];
+  t.deepEqual(Array.from(translationIds), expected);
   t.end();
 });
 
@@ -49,39 +49,41 @@ test('translate prop destructured', t => {
   const output = transformFileSync(
     __dirname + '/fixtures/destructured',
     {
-      plugins: [[plugin, {translationIds}]],
+      plugins: ['@babel/transform-react-jsx', [plugin, {translationIds}]],
     }
   );
-  const expected = new Set([
+  const expected = [
     'some.translation'
-  ]);
-  t.deepEqual(translationIds, expected, 'parsed string list');
+  ];
+  t.deepEqual(Array.from(translationIds), expected);
   t.end();
 });
 
- test('mixed', t => {
-   const translationIds = new Set();
-   const output = transformFileSync(
-     __dirname + '/fixtures/mixed',
-     {
-       plugins: [[plugin, {translationIds}]],
-     }
-   );
-   const expected = new Set([
-     'prop.translation',
-     'array.translation',
-   ]);
-   t.deepEqual(translationIds, expected, 'parsed string list');
-   t.end();
- });
+test('mixed', t => {
+  const translationIds = new Set();
+  const output = transformFileSync(
+    __dirname + '/fixtures/mixed',
+    {
+      plugins: ['@babel/transform-react-jsx', [plugin, {translationIds}]],
+    }
+  );
+  const expected = [
+    'array.translation',
+    'jsx.translation',
+    'prop.translation',
+    'subfn.translation'
+  ];
+  t.deepEqual(Array.from(translationIds).sort(), expected);
+  t.end();
+});
 
- test('non-string arg', t => {
+test('non-string arg', t => {
   const translationIds = new Set();
   function output () {
     transformFileSync(
       __dirname + '/fixtures/non-string-arg',
       {
-        plugins: [[plugin, {translationIds}]],
+        plugins: ['@babel/transform-react-jsx', [plugin, {translationIds}]],
       }
     );
   };

--- a/test/fixtures/dynamic-import-app/src/split-route-content.js
+++ b/test/fixtures/dynamic-import-app/src/split-route-content.js
@@ -2,8 +2,8 @@
 
 import React from 'react';
 
-const SplitRouteContent = function() {
-  return <div>split-route-content</div>;
+const SplitRouteContent = function({text}) {
+  return <div>{text}</div>;
 };
 
 export default SplitRouteContent;

--- a/test/fixtures/dynamic-import-app/src/split-route.js
+++ b/test/fixtures/dynamic-import-app/src/split-route.js
@@ -7,7 +7,7 @@ import SplitRouteContent from './split-route-content';
 
 class SplitRoute extends Component<*, *> {
   render() {
-    return <SplitRouteContent />;
+    return <SplitRouteContent text={this.props.translate('some.translation')} />;
   }
 }
 


### PR DESCRIPTION
It's a pain keeping the list of translation key strings up to date with what's actually in use in the component. It'd be a lot cleaner if we automatically parsed calls to translate to collect strings.

Since `translationIds` is a Set, there's no downside to adding the same string multiple times (both from the `withTranslations` first array argument, or to multiple calls to `this.props.translate`.

Upsides of this pull implementation:
* Lot less manual management
* No risk of forgotten strings causing translation string to silently show up in UI -- currently no warning if `translate` can't find the string in the dictionary
* Only checks the `refPath` scope for `withTranslations` so will never translate a file that doesn't import `withTranslations`. 

Downsides:
* Translate function can't be reassigned (i.e. `const t = this.props.translate`, or `this.renderSomething({t: translate})`). Could be fixed if we walked the scope hierarchy or kept state.
* Doesn't resolve where translate function came from, so could incorrectly parse another translate function. This could be fixed if we use `TranslateType` flowtype as a hint. 