### PR TITLE
Add styletron-react displayName babel transform

### DIFF
--- a/build/get-babel-config.js
+++ b/build/get-babel-config.js
@@ -146,6 +146,7 @@ function fusionPreset(
       require.resolve('./babel-plugins/babel-plugin-sw'),
       require.resolve('./babel-plugins/babel-plugin-sync-chunk-paths'),
       require.resolve('./babel-plugins/babel-plugin-chunkid'),
+      require.resolve('babel-plugin-transform-styletron-display-name'),
       [
         require.resolve('babel-plugin-transform-cup-globals'),
         {target: targetEnv},

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-jest": "^23.6.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "babel-plugin-transform-cup-globals": "^1.0.1",
+    "babel-plugin-transform-styletron-display-name": "^1.0.1",
     "bundle-analyzer": "^0.0.6",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "chalk": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2069,6 +2069,11 @@ babel-plugin-transform-cup-globals@^1.0.1:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-cup-globals/-/babel-plugin-transform-cup-globals-1.0.1.tgz#d4edfd5d629932d0e5467a2b65987baa6da22a9b"
   integrity sha1-1O39XWKZMtDlRnorZZh7qm2iKps=
 
+babel-plugin-transform-styletron-display-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-styletron-display-name/-/babel-plugin-transform-styletron-display-name-1.0.1.tgz#8e7808e49d394b1299379922fef7f2850ef5ce18"
+  integrity sha512-J+B5g81PVYEwDYnfwCzRmSnUgnySJo8cBdk+qhFxwkHROl3Uyhk971naiba90fqD4SvF1YzPfGsBpA1nIzoMQA==
+
 babel-preset-jest@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"


### PR DESCRIPTION
[link](https://github.com/styletron/styletron/tree/master/packages/babel-plugin-transform-styletron-display-name) to package readme.
When creating a component with `styletron-react`, it does not have a `displayName`. This leads to unclear component names in react dev tools. 