### PR TITLE
Serve modern bundles to Chromium

### DIFF
--- a/plugins/ssr-plugin.js
+++ b/plugins/ssr-plugin.js
@@ -162,7 +162,7 @@ Rather than enable terser workarounds that reduces minification for compliant br
 Safari 10.1 and 11 should be treated as legacy.
 */
 function checkModuleSupport({name, version}) {
-  if (name === 'Chrome' || name === 'Chrome Headless') {
+  if (name === 'Chrome' || name === 'Chrome Headless' || name === 'Chromium') {
     if (majorVersion(version) >= 61) return true;
   } else if (name === 'Mobile Safari' || name === 'Safari') {
     if (majorVersion(version) >= 12) return true;


### PR DESCRIPTION
The user agent parser identifies Chromium as a different browser, but it should be served modern bundles.