### PR TITLE
Remove duplicated worker index

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,7 +42,7 @@ steps:
         run: fusion-cli-node-last
     agents:
       queue: workers
-  - name: ':node: :white_check_mark: worker %n'
+  - name: ':node: :white_check_mark:'
     parallelism: 5
     command: .buildkite/nodeTests
     plugins:
@@ -50,7 +50,7 @@ steps:
         run: fusion-cli
     agents:
       queue: workers
-  - name: ':node: :white_check_mark: node8 worker %n'
+  - name: ':node: :white_check_mark: node8'
     parallelism: 5
     command: .buildkite/nodeTests
     plugins:


### PR DESCRIPTION
Buildkite has recently added a worker index/total display to the UI so we no longer need to output this ourselves.

You can see the new index display here:

![image](https://user-images.githubusercontent.com/122602/51342095-cdd80f80-1a47-11e9-9d3a-98574a853440.png)
