### PR TITLE
Fix browser field resolution in dependencies of sw bundle when es2015/es2017 fields are present

### DIFF
--- a/build/get-webpack-config.js
+++ b/build/get-webpack-config.js
@@ -392,7 +392,7 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
     ].filter(Boolean),
     resolve: {
       aliasFields: [
-        runtime === 'client' && 'browser',
+        (runtime === 'client' || runtime === 'sw') && 'browser',
         'es2015',
         'es2017',
       ].filter(Boolean),

--- a/test/e2e/noop-sw/fixture/src/other/dist/browser.es2015.es.js
+++ b/test/e2e/noop-sw/fixture/src/other/dist/browser.es2015.es.js
@@ -1,0 +1,2 @@
+// @flow
+export default 'browser.es2015.es.js';

--- a/test/e2e/noop-sw/fixture/src/other/dist/browser.es2017.es.js
+++ b/test/e2e/noop-sw/fixture/src/other/dist/browser.es2017.es.js
@@ -1,0 +1,2 @@
+// @flow
+export default 'browser.es2017.es.js';

--- a/test/e2e/noop-sw/fixture/src/other/dist/browser.es5.es.js
+++ b/test/e2e/noop-sw/fixture/src/other/dist/browser.es5.es.js
@@ -1,0 +1,2 @@
+// @flow
+export default 'browser.es5.es.js';

--- a/test/e2e/noop-sw/fixture/src/other/dist/browser.es5.js
+++ b/test/e2e/noop-sw/fixture/src/other/dist/browser.es5.js
@@ -1,0 +1,2 @@
+// @flow
+export default 'browser.es5.js';

--- a/test/e2e/noop-sw/fixture/src/other/dist/index.es.js
+++ b/test/e2e/noop-sw/fixture/src/other/dist/index.es.js
@@ -1,0 +1,2 @@
+// @flow
+export default 'index.es.js';

--- a/test/e2e/noop-sw/fixture/src/other/dist/index.js
+++ b/test/e2e/noop-sw/fixture/src/other/dist/index.js
@@ -1,0 +1,2 @@
+// @flow
+export default 'index.js';

--- a/test/e2e/noop-sw/fixture/src/other/package.json
+++ b/test/e2e/noop-sw/fixture/src/other/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "other",
+  "main": "./dist/index.js",
+  "module": "./dist/index.es.js",
+  "browser": {
+    "./dist/index.js": "./dist/browser.es5.js",
+    "./dist/index.es.js": "./dist/browser.es5.es.js"
+  },
+  "es2015": {
+    "./dist/browser.es5.es.js": "./dist/browser.es2015.es.js"
+  },
+  "es2017": {
+    "./dist/browser.es5.es.js": "./dist/browser.es2017.es.js",
+    "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
+  }
+}

--- a/test/e2e/noop-sw/fixture/src/sw.js
+++ b/test/e2e/noop-sw/fixture/src/sw.js
@@ -1,5 +1,7 @@
 // @flow
 
+import other from './other';
+
 export default function abc(arg /*: any*/) {
-  return arg;
+  return [arg, other];
 }

--- a/test/e2e/noop-sw/test.js
+++ b/test/e2e/noop-sw/test.js
@@ -21,7 +21,7 @@ test('sw bundle works with serialized/deserialized arguments', async () => {
   const result = await request(`http://localhost:${port}/sw.js`);
   t.deepEqual(
     eval(result),
-    {foo: 'bar'},
+    [{foo: 'bar'}, 'browser.es2017.es.js'],
     'arguments serialized/deserialized correctly'
   );
 


### PR DESCRIPTION
Vanilla browser field was working before, but not when es2015/es2017 fields were present.

This adds a fix and regression test.