### PR TITLE
Fix testing with hoisted node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The CLI API can be most easily run through the Yarn or NPX CLI, e.g. `yarn fusio
   - `--testFolder`: Which folder to look for tests in. Deprecated, use testMatch or testRegex instead.
   - `--testMatch`: Which folder to look for tests in. A comma-separated list of glob patterns.
   - `--testRegex`: Which folder to look for tests in. A comma-separated list of regexp strings.
-  - `--configPath`: Path to the jest configuration, used for testing.  (default ./node_modules/fusion-cli/build/jest/jest-config.js)
+  - `--configPath`: Path to the jest configuration, used for testing.  (default [path-to-fusion-cli]/build/jest/jest-config.js)
   - `--updateSnapshot`, `-u`: Updates snapshots
 
   Jest pass-through options

--- a/build/test-runtime.js
+++ b/build/test-runtime.js
@@ -25,7 +25,7 @@ module.exports.TestAppRuntime = function(
     testRegex,
     updateSnapshot,
     collectCoverageFrom,
-    configPath,
+    configPath = `${__dirname}/jest/jest-config.js`,
     jestArgs = {},
   } /*: any */
 ) {

--- a/commands/index.js
+++ b/commands/index.js
@@ -175,7 +175,6 @@ module.exports = {
       },
       configPath: {
         type: 'string',
-        default: './node_modules/fusion-cli/build/jest/jest-config.js',
         describe: 'Path to the jest configuration, used for testing.',
       },
       ...jestOptionsDescriptions,


### PR DESCRIPTION
`fusion test` currently breaks if node_modules is hoisted (e.g. in a yarn workspace) due to hard-coding  of the default jest config file. This PR changes the default config file to rely on __dirname for absolute filesystem path rather than relying on relative path from cwd