### PR TITLE
Release v1.16.0-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fusion-cli",
-  "version": "1.16.0-1",
+  "version": "1.16.0-2",
   "description": "CLI",
   "repository": "fusionjs/fusion-cli",
   "bin": {


### PR DESCRIPTION
- Use graphql-tag loader for fragment import support ([#688](https://github.com/fusionjs/fusion-cli/pull/688))
- Fix testing with hoisted node_modules ([#685](https://github.com/fusionjs/fusion-cli/pull/685))
- Upgrade jest/babel-jest ([#683](https://github.com/fusionjs/fusion-cli/pull/683))
- Pass timestamp as unused argument so sw.js updated for each build ([#680](https://github.com/fusionjs/fusion-cli/pull/680))