### PR TITLE
Add module id dynamic import instrumentation

### DIFF
--- a/build/plugins/instrumented-import-dependency-template-plugin.js
+++ b/build/plugins/instrumented-import-dependency-template-plugin.js
@@ -69,11 +69,14 @@ class InstrumentedImportDependencyTemplate extends ImportDependencyTemplate {
       chunkIds = getChunkGroupIds(depBlock.chunkGroup);
     }
 
-    // Add `__CHUNK_IDS` property to promise returned by `import()`` if they exist
+    // Add the following properties to the promise returned by import()
+    // - `__CHUNK_IDS`: the webpack chunk ids for the dynamic import
+    // - `__MODULE_ID`: the webpack module id of the dynamically imported module. Equivalent to require.resolveWeak(path)
     const customContent = chunkIds
-      ? `Object.defineProperty(${content}, "__CHUNK_IDS", {value:${JSON.stringify(
-          chunkIds
-        )}})`
+      ? `Object.defineProperties(${content}, {
+        "__CHUNK_IDS": {value:${JSON.stringify(chunkIds)}},
+        "__MODULE_ID": {value:${JSON.stringify(dep.module.id)}}
+        })`
       : content;
 
     // replace with `customContent` instead of `content`

--- a/build/plugins/instrumented-import-dependency-template-plugin.js
+++ b/build/plugins/instrumented-import-dependency-template-plugin.js
@@ -18,8 +18,8 @@ const ImportDependencyTemplate = require('webpack/lib/dependencies/ImportDepende
 
 /**
  * We create an extension to the original ImportDependency template
- * that adds an extra property to the promise returned by import()
- * that has the corresponding chunkId and module id.
+ * that adds extra properties to the promise returned by import()
+ * for its corresponding chunkId and module id.
  *
  * At a high level, if module `foo.js` had module id "abc" and was in chunk with id 5, we turn:
  *

--- a/build/plugins/instrumented-import-dependency-template-plugin.js
+++ b/build/plugins/instrumented-import-dependency-template-plugin.js
@@ -19,17 +19,17 @@ const ImportDependencyTemplate = require('webpack/lib/dependencies/ImportDepende
 /**
  * We create an extension to the original ImportDependency template
  * that adds an extra property to the promise returned by import()
- * that has the chunkId.
+ * that has the corresponding chunkId and module id.
  *
- * At a high level, if module `foo` was in chunk with id 5, we turn:
+ * At a high level, if module `foo.js` had module id "abc" and was in chunk with id 5, we turn:
  *
- * import('foo')
+ * import('./foo.js')
  * // Returns a promise
  *
  * into:
  *
- * Object.defineProperty(import('foo'), {__CHUNK_IDS: [5]})
- * // Also returns a promise, but with an extra non-enumerable property
+ * Object.defineProperties(import('./foo.js'), {__CHUNK_IDS: [5], __MODULE_ID: "abc"})
+ * // Also returns a promise, but with extra non-enumerable properties
  */
 
 class InstrumentedImportDependencyTemplate extends ImportDependencyTemplate {
@@ -42,8 +42,8 @@ class InstrumentedImportDependencyTemplate extends ImportDependencyTemplate {
     }
   }
   /**
-   * TODO(#15): Possibly figure out cleaner implementation by extending `super` to avoid duplicating code
-   * For now, we'll just override this method entirely with a modified version
+   * It may be possible to avoid duplicating code by extending `super`, but
+   * for now, we'll just override this method entirely with a modified version
    * Based on https://github.com/webpack/webpack/blob/5e38646f589b5b6325556f3127e7b61df33d3cb9/lib/dependencies/ImportDependency.js
    */
   apply(dep /*: any */, source /*: any */, runtime /*: any */) {


### PR DESCRIPTION
This is will enable [future changes to fusion-react](https://github.com/fusionjs/fusion-react/pull/227), including
- Removal of client-side `prepare` step
- Replacing custom React tree traversal algorithm in `prepare` with `renderToStaticMarkup` (which will enable hook support)

In particular, adding this instrumentation will enable the component returned by `split` to synchronously check if the module being dynamically imported has already been loaded (i.e. because it was preloaded on SSR) and then synchronously import it and render the component.