### PR TITLE
Improve test reliability

### DIFF
--- a/test/e2e/test-jest-app/test.js
+++ b/test/e2e/test-jest-app/test.js
@@ -19,6 +19,8 @@ const runnerPath = require.resolve('../../../bin/cli-runner');
 
 const dir = path.resolve(__dirname, './fixture');
 
+jest.setTimeout(10000);
+
 test('`fusion test` passes', async () => {
   const args = `test --dir=${dir} --configPath=../../../../build/jest/jest-config.js --match=passes`;
 


### PR DESCRIPTION
Tests currently fail intermittently on test-jest-app suite due to timeouts. Increasing the timeout seems to fix it