### PR TITLE
Add deps that are required by tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-react": "^7.11.1",
     "flow-bin": "^0.89.0",
     "fusion-core": "1.10.2",
+    "fusion-plugin-i18n": "^1.2.0",
     "fusion-plugin-i18n-react": "^1.2.3",
     "fusion-plugin-react-router": "^1.4.2",
     "fusion-plugin-universal-events": "^1.3.2",
@@ -79,13 +80,15 @@
     "fusion-tokens": "^1.1.1",
     "globby": "^8.0.1",
     "graphql": "^14.1.1",
+    "locale": "^0.1.0",
     "prettier": "^1.15.2",
     "puppeteer": "^1.10.0",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-test-renderer": "^16.6.3",
     "request-promise": "4.2.2",
-    "tape": "4.9.1"
+    "tape": "4.9.1",
+    "unfetch": "^4.0.1"
   },
   "peerDependencies": {
     "fusion-core": "^1.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7819,6 +7819,11 @@ uglify-js@^3.1.4:
     commander "~2.17.1"
     source-map "~0.6.1"
 
+unfetch@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.0.1.tgz#8750c4c7497ade75d40387d7dbc4ba024416b8f6"
+  integrity sha512-HzDM9NgldcRvHVDb/O9vKoUszVij30Yw5ePjOZJig8nF/YisG7QN/9CBXZ8dsHLouXMeLZ82r+Jod9M2wFkEbQ==
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"


### PR DESCRIPTION
We need to do this because fusion-cli expects node_modules to be populated w/ code required by fixtures.

This works under a single repo scenario w/ yarn because yarn hoists transitive deps, but fails in a monorepo structure where folder structure is strict (e.g. pnpm or rush)

To allow node resolution algorithm to find the expected deps without hitting network on each test, we instead "hoist" those deps by declaring them as dev deps in the top level of this package.