### PR TITLE
Add 'runInBand' to Jest option whitelist

### DIFF
--- a/build/jest/cli-options.js
+++ b/build/jest/cli-options.js
@@ -29,6 +29,7 @@ exports.allowedJestOptions = [
   'onlyChanged',
   'passWithNoTests',
   'reporters',
+  'runInBand',
   'showConfig',
   'silent',
   'testLocationInResults',


### PR DESCRIPTION
On our project we are seeing issues with integration test timeouts in CI. Running the tests sequentially solves the issues as described in https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server so having this option whitelisted would be extremely valuable.