### PR TITLE
Fix jest test chunking

### DIFF
--- a/.buildkite/nodeTests
+++ b/.buildkite/nodeTests
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-yarn test --testMatch=$(export JOB_COUNT=$BUILDKITE_PARALLEL_JOB_COUNT; export JOB_INDEX=$BUILDKITE_PARALLEL_JOB; node get-test-files.js) || exit 1
+yarn test --testPathPattern=$(export JOB_COUNT=$BUILDKITE_PARALLEL_JOB_COUNT; export JOB_INDEX=$BUILDKITE_PARALLEL_JOB; node get-test-files.js) || exit 1
 bash <(curl -s https://codecov.io/bash) -f coverage/coverage-final.json -n node

--- a/get-test-files.js
+++ b/get-test-files.js
@@ -43,4 +43,4 @@ const files = getFiles();
  * a new glob pattern which will match all of the
  * selected files, exclusively.
  */
-process.stdout.write(files.map(str => '**/' + str).join('|'));
+process.stdout.write(files.map(str => '.*/' + str).join('|'));


### PR DESCRIPTION
Currently it seems we're only running a subset of fusion-cli tests in CI. I believe this is because testMatch is not a valid jest CLI flag, while testPathPattern is. Use testPathPattern and convert globs to regex.

This seems to have been broken in the jest update here: https://github.com/fusionjs/fusion-cli/commit/d84c834f805fcdb32caf619eca24a326270d6974

I looked through the Jest changelog but did not see references to removing this flag. It could be that this flag was undocumented, and we just got lucky that it worked.

Current output on master for first test chunk:
![image](https://user-images.githubusercontent.com/122602/54164273-42607680-4419-11e9-93c9-2e263b40ef81.png)
