### PR TITLE
Adding file list to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,17 @@
     "lint": "eslint .",
     "test": "git clean -Xfd test/fixtures && jest --maxWorkers 1"
   },
+  "files": [
+    "bin/",
+    "build/",
+    "commands/",
+    "entries/",
+    "lib/",
+    "plugins/",
+    "get-compilation-metadata.js",
+    "README.md",
+    "LICENSE"
+  ],
   "dependencies": {
     "@babel/core": "^7.1.6",
     "@babel/plugin-syntax-dynamic-import": "7.2.0",


### PR DESCRIPTION
fusion-cli npm modules includes all the files from source which makes it heavy.
Hence included only required files.