### PR TITLE
Make tests less reliant on how exactly babel transpiles template strings

### DIFF
--- a/test/e2e/empty/test.js
+++ b/test/e2e/empty/test.js
@@ -10,6 +10,8 @@ const dir = path.resolve(__dirname, './fixture');
 
 const {cmd} = require('../utils.js');
 
+jest.setTimeout(10000);
+
 test('generates error if missing default export', async () => {
   await cmd(`build --dir=${dir}`);
 

--- a/test/e2e/gql/test.js
+++ b/test/e2e/gql/test.js
@@ -21,7 +21,7 @@ const dev = require('../setup.js');
 
 const dir = path.resolve(__dirname, './fixture');
 
-jest.setTimeout(100000)
+jest.setTimeout(100000);
 
 test('`fusion dev` works with gql', async () => {
   const app = dev(dir);

--- a/test/e2e/gql/test.js
+++ b/test/e2e/gql/test.js
@@ -21,6 +21,8 @@ const dev = require('../setup.js');
 
 const dir = path.resolve(__dirname, './fixture');
 
+jest.setTimeout(100000)
+
 test('`fusion dev` works with gql', async () => {
   const app = dev(dir);
   await app.setup();
@@ -67,7 +69,7 @@ type User {
     t.ifError(e);
   }
   app.teardown();
-}, 100000);
+});
 
 test('`fusion build --production` works with gql', async () => {
   let browser;
@@ -122,7 +124,7 @@ type User {
   // $FlowFixMe
   browser.close();
   proc.kill();
-}, 100000);
+});
 
 test('`fusion test` with gql macro', async () => {
   const args = `test --dir=${dir} --configPath=../../../../build/jest/jest-config.js`;

--- a/test/e2e/noop-test/fixture/src/main.js
+++ b/test/e2e/noop-test/fixture/src/main.js
@@ -2,8 +2,8 @@
 import App from 'fusion-core';
 
 export default async function() {
-  console.log(`main __BROWSER__ is ${__BROWSER__}`);
-  console.log(`main __DEV__ is ${__DEV__}`);
-  console.log(`main __NODE__ is ${__NODE__}`);
+  console.log('main __BROWSER__ is', __BROWSER__);
+  console.log('main __DEV__ is', __DEV__);
+  console.log('main __NODE__ is', __NODE__);
   return new App('el', el => el);
 }

--- a/test/e2e/noop-test/test.js
+++ b/test/e2e/noop-test/test.js
@@ -31,11 +31,11 @@ test('development env globals', async () => {
   const clientContent = await readFile(clientEntryPath, 'utf8');
 
   t.ok(
-    clientContent.includes('`main __BROWSER__ is ${true}`'),
+    clientContent.includes(`'main __BROWSER__ is', true`),
     `__BROWSER__ is transpiled to be true in development`
   );
   t.ok(
-    clientContent.includes('`main __NODE__ is ${false}`'),
+    clientContent.includes(`'main __NODE__ is', false`),
     '__NODE__ is transpiled to be false'
   );
 
@@ -86,12 +86,12 @@ test('production env globals', async () => {
   const entry = path.resolve(dir, entryPath);
 
   t.ok(
-    clientContent.includes('"main __BROWSER__ is true"'),
+    clientContent.includes('"main __BROWSER__ is",!0'),
     `__BROWSER__ is transpiled to be true in production`
   );
 
   t.ok(
-    clientContent.includes('"main __NODE__ is false"'),
+    clientContent.includes('"main __NODE__ is",!1'),
     '__NODE__ is transpiled to be false'
   );
 

--- a/test/e2e/noop/test.js
+++ b/test/e2e/noop/test.js
@@ -16,6 +16,8 @@ const {cmd, dev, run, start} = require('../utils.js');
 
 const dir = path.resolve(__dirname, './fixture');
 
+jest.setTimeout(20000);
+
 test('`fusion dev --dir` works w/ relative dir', async () => {
   const entryPath = `.fusion/dist/development/server/server-main.js`;
   const entry = path.resolve(dir, entryPath);

--- a/test/e2e/test-jest-app/test.js
+++ b/test/e2e/test-jest-app/test.js
@@ -19,7 +19,7 @@ const runnerPath = require.resolve('../../../bin/cli-runner');
 
 const dir = path.resolve(__dirname, './fixture');
 
-jest.setTimeout(10000);
+jest.setTimeout(20000);
 
 test('`fusion test` passes', async () => {
   const args = `test --dir=${dir} --configPath=../../../../build/jest/jest-config.js --match=passes`;

--- a/test/e2e/test-jest-babel/test.js
+++ b/test/e2e/test-jest-babel/test.js
@@ -14,6 +14,8 @@ const runnerPath = require.resolve('../../../bin/cli-runner');
 
 const dir = path.resolve(__dirname, './fixture');
 
+jest.setTimeout(10000);
+
 test('`fusion test` uses .fusionjs.js', async () => {
   const args = `test --dir=${dir} --configPath=../../../../build/jest/jest-config.js`;
 


### PR DESCRIPTION
Also prevent common timeouts

Background: syncing to the monorepo is breaking some tests. Upstreaming fixes here.