### PR TITLE
Fix EventEmitter leak in dev-runtime

### DIFF
--- a/build/dev-runtime.js
+++ b/build/dev-runtime.js
@@ -27,6 +27,7 @@ function Lifecycle() {
   return {
     start: () => {
       state.started = true;
+      state.error = undefined;
       emitter.emit('message');
     },
     stop: () => {
@@ -48,6 +49,7 @@ function Lifecycle() {
           listening = true;
           emitter.once('message', (error /*: Error */) => {
             if (error) {
+              listening = false;
               return reject(error);
             }
 

--- a/build/dev-runtime.js
+++ b/build/dev-runtime.js
@@ -27,18 +27,16 @@ function Lifecycle() {
   return {
     start: () => {
       state.started = true;
-      state.error = undefined;
-      emitter.emit('started');
+      emitter.emit('message');
     },
     stop: () => {
       state.started = false;
     },
     error: error => {
-      state.error = error;
       // The error listener may emit before we call wait.
       // Make sure that we're listening before attempting to emit.
       if (listening) {
-        emitter.emit('error');
+        emitter.emit('message', error);
       }
     },
     wait: () => {
@@ -47,10 +45,13 @@ function Lifecycle() {
         else if (state.error) reject(state.error);
         else {
           listening = true;
-          emitter.once('started', resolve);
-          emitter.once('error', () => {
-            listening = false;
-            reject(state.error);
+          emitter.once('message', (error /*: Error */) => {
+            if (error) {
+              state.error = error;
+              return reject(error);
+            }
+
+            resolve();
           });
         }
       });

--- a/build/dev-runtime.js
+++ b/build/dev-runtime.js
@@ -35,6 +35,7 @@ function Lifecycle() {
     error: error => {
       // The error listener may emit before we call wait.
       // Make sure that we're listening before attempting to emit.
+      state.error = error;
       if (listening) {
         emitter.emit('message', error);
       }
@@ -47,7 +48,6 @@ function Lifecycle() {
           listening = true;
           emitter.once('message', (error /*: Error */) => {
             if (error) {
-              state.error = error;
               return reject(error);
             }
 

--- a/build/dev-runtime.js
+++ b/build/dev-runtime.js
@@ -33,9 +33,9 @@ function Lifecycle() {
       state.started = false;
     },
     error: error => {
+      state.error = error;
       // The error listener may emit before we call wait.
       // Make sure that we're listening before attempting to emit.
-      state.error = error;
       if (listening) {
         emitter.emit('message', error);
       }

--- a/test/e2e/server-startup-control/test.js
+++ b/test/e2e/server-startup-control/test.js
@@ -17,7 +17,7 @@ test('`fusion dev` proxy gracefully recovers from cached SSR errors', async () =
   async function waitForCompileToStart() {
     // Once the Fusion.js application renders SSR error pages in the app
     // we should leverage module.hot.addStatusHandler.
-    await new Promise(resolve => setTimeout(resolve, 3000));
+    await new Promise(resolve => setTimeout(resolve, 10000));
   }
 
   const url = app.url();


### PR DESCRIPTION
Lifecycle registered two event listeners using `once`. Only one would
unregister itself, leading to us leaking emitters. This could
potentially bring down the Fusion server as calls to `lifecycle.wait()`
would hang.