### PR TITLE
See if we can revert setTimeout change

### DIFF
--- a/test/e2e/server-startup-control/test.js
+++ b/test/e2e/server-startup-control/test.js
@@ -17,7 +17,7 @@ test('`fusion dev` proxy gracefully recovers from cached SSR errors', async () =
   async function waitForCompileToStart() {
     // Once the Fusion.js application renders SSR error pages in the app
     // we should leverage module.hot.addStatusHandler.
-    await new Promise(resolve => setTimeout(resolve, 10000));
+    await new Promise(resolve => setTimeout(resolve, 3000));
   }
 
   const url = app.url();


### PR DESCRIPTION
Introduced in https://github.com/fusionjs/fusion-cli/pull/752, just want to see if this is necessary since that PR made additional changes afterwards. Not much impact here, just adds some extra time in the test chunk.