### PR TITLE
Change webpack dev sourcemap strategy to cheap-eval-source-map

### DIFF
--- a/build/get-webpack-config.js
+++ b/build/get-webpack-config.js
@@ -236,7 +236,7 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
     devtool:
       (runtime === 'client' && !dev) || runtime === 'sw'
         ? 'hidden-source-map'
-        : 'cheap-module-source-map',
+        : 'cheap-eval-source-map',
     output: {
       path: path.join(dir, `.fusion/dist/${env}/${runtime}`),
       filename:


### PR DESCRIPTION
Addresses WPT-1864.

Our previous source map strategy was not bundling all of the individual source map files in node_modules into the final vendor.js.map file. By my rough estimations less than 25% of our fusion plugins were being added to the final generated mapping file. I cannot say why as attempting to track down the reasons didn't really lead anywhere after hours of learning about how this stuff works.

I started investigating alternative source map strategies and basically any strategy that allows source map debugging in original code would break. Anything else that uses generated or transformed code was fine though. So I picked the best one for dev based on that with fast build and rebuild speeds.

![image](https://user-images.githubusercontent.com/19541187/56068457-c5842d80-5d33-11e9-87e1-338be5320760.png)
![image](https://user-images.githubusercontent.com/19541187/56068331-455dc800-5d33-11e9-9640-805c0ea0b4e1.png)
![image](https://user-images.githubusercontent.com/19541187/56068472-d2088600-5d33-11e9-8ecf-8aef99a9de99.png)

Our previous pick was:

![image](https://user-images.githubusercontent.com/19541187/56068461-c7e68780-5d33-11e9-8010-0f1573626e80.png)
![image](https://user-images.githubusercontent.com/19541187/56068343-4d1d6c80-5d33-11e9-86e6-ac145dc01c12.png)
![image](https://user-images.githubusercontent.com/19541187/56068474-d46ae000-5d33-11e9-80cc-a5be5e9dd898.png)

Going by the chart it seems like our previous pick wasn't the best? Webpack doesn't recommend it for dev or production but only for special situations which I am unaware of.

An alternative approach would be to figure out why original source source maps aren't working. The documentation says this depends on loader support so something could be wrong with our loaders. I'm ok with going down that route if we don't want to settle with transpiled code source maps. 

Personally it doesn't bother me that much since I can recognize what the code is doing even if it was transpiled but I can see the arguments for preserving the original code for maximum debugability.