### PR TITLE
Update base jest config to ignore __generated__ directory when collecting coverage

### DIFF
--- a/build/jest/base-jest-config.js
+++ b/build/jest/base-jest-config.js
@@ -52,6 +52,7 @@ module.exports = {
   testURL: 'http://localhost:3000/',
   collectCoverageFrom: [
     'src/**/*.js',
+    '!**/__generated__/**',
     '!**/__integration__/**',
     '!**/__tests__/**',
     '!**/node_modules/**',


### PR DESCRIPTION
Many code generation tools follow this pattern, so it makes sense to ignore this
file pattern by default.