### PR TITLE
Add translation key instrumentation for dynamic imports

### DIFF
--- a/build/compiler.js
+++ b/build/compiler.js
@@ -153,7 +153,8 @@ function Compiler(
     clientChunkMetadata,
     legacyClientChunkMetadata,
     mergedClientChunkMetadata,
-    i18nManifest: new DeferredState(),
+    i18nManifest: new Map(),
+    i18nDeferredManifest: new DeferredState(),
     legacyBuildEnabled,
   };
   const root = path.resolve(dir);

--- a/build/get-webpack-config.js
+++ b/build/get-webpack-config.js
@@ -65,6 +65,7 @@ const JS_EXT_PATTERN = /\.jsx?$/;
 /*::
 import type {
   ClientChunkMetadataState,
+  TranslationsManifest,
   TranslationsManifestState,
   LegacyBuildEnabledState,
 } from "./types.js";
@@ -86,7 +87,7 @@ export type WebpackConfigOpts = {|
     clientChunkMetadata: ClientChunkMetadataState,
     legacyClientChunkMetadata: ClientChunkMetadataState,
     mergedClientChunkMetadata: ClientChunkMetadataState,
-    i18nManifest: Map<string, Set<string>>,
+    i18nManifest: TranslationManifest,
     i18nDeferredManifest: TranslationsManifestState,
     legacyBuildEnabled: LegacyBuildEnabledState,
   },

--- a/build/get-webpack-config.js
+++ b/build/get-webpack-config.js
@@ -472,18 +472,19 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
       watch && new webpack.NoEmitOnErrorsPlugin(),
       runtime === 'server'
         ? // Server
-          new InstrumentedImportDependencyTemplatePlugin(
-            state.mergedClientChunkMetadata
-          )
+          new InstrumentedImportDependencyTemplatePlugin({
+            compilation: 'server',
+            clientChunkMetadata: state.mergedClientChunkMetadata,
+          })
         : /**
            * Client
            * Don't wait for the client manifest on the client.
            * The underlying plugin is able determine client chunk metadata on its own.
            */
-          new InstrumentedImportDependencyTemplatePlugin(
-            void 0,
-            state.i18nManifest
-          ),
+          new InstrumentedImportDependencyTemplatePlugin({
+            compilation: 'client',
+            i18nManifest: state.i18nManifest,
+          }),
       dev && hmr && watch && new webpack.HotModuleReplacementPlugin(),
       !dev && runtime === 'client' && new webpack.HashedModuleIdsPlugin(),
       runtime === 'client' &&
@@ -535,10 +536,10 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
               options.optimization.splitChunks
             ),
             // need to re-apply template
-            new InstrumentedImportDependencyTemplatePlugin(
-              void 0,
-              state.i18nManifest
-            ),
+            new InstrumentedImportDependencyTemplatePlugin({
+              compilation: 'client',
+              i18nManifest: state.i18nManifest,
+            }),
             new ClientChunkMetadataStateHydratorPlugin(
               state.legacyClientChunkMetadata
             ),

--- a/build/get-webpack-config.js
+++ b/build/get-webpack-config.js
@@ -478,7 +478,7 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
         : /**
            * Client
            * Don't wait for the client manifest on the client.
-           * The underlying plugin handles client instrumentation on its own.
+           * The underlying plugin is able determine client chunk metadata on its own.
            */
           new InstrumentedImportDependencyTemplatePlugin(
             void 0,

--- a/build/get-webpack-config.js
+++ b/build/get-webpack-config.js
@@ -87,7 +87,7 @@ export type WebpackConfigOpts = {|
     clientChunkMetadata: ClientChunkMetadataState,
     legacyClientChunkMetadata: ClientChunkMetadataState,
     mergedClientChunkMetadata: ClientChunkMetadataState,
-    i18nManifest: TranslationManifest,
+    i18nManifest: TranslationsManifest,
     i18nDeferredManifest: TranslationsManifestState,
     legacyBuildEnabled: LegacyBuildEnabledState,
   },

--- a/build/plugins/i18n-discovery-plugin.js
+++ b/build/plugins/i18n-discovery-plugin.js
@@ -16,33 +16,30 @@ import type {TranslationsManifestState, TranslationsManifest} from "../types.js"
 
 class I18nDiscoveryPlugin {
   /*::
-  manifest: TranslationsManifestState;
-  discoveryState: Map<string, Set<string>>;
+  manifestState: TranslationsManifestState;
+  manifest: TranslationsManifest;
   */
   constructor(
-    deferredManifest /*: TranslationsManifestState*/,
-    discoveryState /*: Map<string, Set<string>>*/
+    manifestState /*: TranslationsManifestState*/,
+    manifest /*: TranslationsManifest*/
   ) {
-    this.manifest = deferredManifest;
-    this.discoveryState = discoveryState;
+    this.manifestState = manifestState;
+    this.manifest = manifest;
   }
   apply(compiler /*: any */) {
     const name = this.constructor.name;
     // "thisCompilation" is not run in child compilations
     compiler.hooks.thisCompilation.tap(name, compilation => {
       compilation.hooks.normalModuleLoader.tap(name, (context, module) => {
-        context[translationsDiscoveryKey] = this.discoveryState;
+        context[translationsDiscoveryKey] = this.manifest;
       });
     });
-    // if resolve at 'make' - discoverState will be empty
-    // if resolve at 'afterCompile' or 'done' - instrumentation plugin is
-    //  waiting for this to resolve from the 'make' step - build breaks
     compiler.hooks.done.tap(name, () => {
-      this.manifest.resolve(this.discoveryState);
+      this.manifestState.resolve(this.manifest);
     });
     compiler.hooks.invalid.tap(name, filename => {
-      this.manifest.reset();
-      this.discoveryState.delete(filename);
+      this.manifestState.reset();
+      this.manifest.delete(filename);
     });
   }
 }

--- a/build/plugins/i18n-discovery-plugin.js
+++ b/build/plugins/i18n-discovery-plugin.js
@@ -17,11 +17,14 @@ import type {TranslationsManifestState, TranslationsManifest} from "../types.js"
 class I18nDiscoveryPlugin {
   /*::
   manifest: TranslationsManifestState;
-  discoveryState: TranslationsManifest;
+  discoveryState: Map<string, Set<string>>;
   */
-  constructor(manifest /*: TranslationsManifestState*/) {
-    this.manifest = manifest;
-    this.discoveryState = new Map();
+  constructor(
+    deferredManifest /*: TranslationsManifestState*/,
+    discoveryState /*: Map<string, Set<string>>*/
+  ) {
+    this.manifest = deferredManifest;
+    this.discoveryState = discoveryState;
   }
   apply(compiler /*: any */) {
     const name = this.constructor.name;
@@ -31,6 +34,9 @@ class I18nDiscoveryPlugin {
         context[translationsDiscoveryKey] = this.discoveryState;
       });
     });
+    // if resolve at 'make' - discoverState will be empty
+    // if resolve at 'afterCompile' or 'done' - instrumentation plugin is
+    //  waiting for this to resolve from the 'make' step - build breaks
     compiler.hooks.done.tap(name, () => {
       this.manifest.resolve(this.discoveryState);
     });

--- a/build/plugins/instrumented-import-dependency-template-plugin.js
+++ b/build/plugins/instrumented-import-dependency-template-plugin.js
@@ -111,7 +111,7 @@ class InstrumentedImportDependencyTemplate extends ImportDependencyTemplate {
     // Add the following properties to the promise returned by import()
     // - `__CHUNK_IDS`: the webpack chunk ids for the dynamic import
     // - `__MODULE_ID`: the webpack module id of the dynamically imported module. Equivalent to require.resolveWeak(path)
-    // - `__I18N_KEYS`: the translation keys that are used in this bundle
+    // - `__I18N_KEYS`: the translation keys used in the client chunk group for this import() 
     const customContent = chunkIds
       ? `Object.defineProperties(${content}, {
         "__CHUNK_IDS": {value:${JSON.stringify(chunkIds)}},

--- a/build/plugins/instrumented-import-dependency-template-plugin.js
+++ b/build/plugins/instrumented-import-dependency-template-plugin.js
@@ -80,12 +80,24 @@ class InstrumentedImportDependencyTemplate extends ImportDependencyTemplate {
 
     let translationKeys = [];
     if (this.translationsManifest) {
-      const chunks = depBlock.chunkGroup.chunks;
-      const modules = chunks.reduce((acc, chunk) => {
-        const modules = Array.from(chunk._modules.keys());
-        return acc.concat(modules.map(m => m.resource));
-      }, []);
+      const modulesSet = new Set();
 
+      // Module dependencies
+      if (dep.module && dep.module.dependencies) {
+        dep.module.dependencies.map(d => {
+          if (d.originModule) {
+            modulesSet.add(d.originModule.userRequest);
+          }
+        });
+      }
+
+      // Chunks
+      depBlock.chunkGroup.chunks.forEach(chunk => {
+        const modules = Array.from(chunk._modules.keys());
+        modules.forEach(m => modulesSet.add(m.resource));
+      });
+
+      const modules = Array.from(modulesSet.keys());
       translationKeys = modules.reduce((acc, module) => {
         if (this.translationsManifest.has(module)) {
           const keys = Array.from(this.translationsManifest.get(module).keys());

--- a/build/plugins/instrumented-import-dependency-template-plugin.js
+++ b/build/plugins/instrumented-import-dependency-template-plugin.js
@@ -40,7 +40,10 @@ class InstrumentedImportDependencyTemplate extends ImportDependencyTemplate {
   /*:: clientChunkIndex: ?$PropertyType<ClientChunkMetadata, "fileManifest">; */
   /*:: manifest: ?TranslationsManifest; */
 
-  constructor(clientChunkMetadata /*: ?ClientChunkMetadata */, translationsManifest /*: ?TranslationsManifest*/) {
+  constructor(
+    clientChunkMetadata /*: ?ClientChunkMetadata */,
+    translationsManifest /*: ?TranslationsManifest*/
+  ) {
     super();
     this.translationsManifest = translationsManifest;
     if (clientChunkMetadata) {

--- a/build/plugins/instrumented-import-dependency-template-plugin.js
+++ b/build/plugins/instrumented-import-dependency-template-plugin.js
@@ -97,7 +97,6 @@ class InstrumentedImportDependencyTemplate extends ImportDependencyTemplate {
     let translationKeys = [];
     if (this.translationsManifest) {
       const modules = getChunkGroupModules(dep);
-
       for (const module of modules) {
         if (this.translationsManifest.has(module)) {
           const keys = this.translationsManifest.get(module).keys();
@@ -189,8 +188,7 @@ function getChunkGroupIds(chunkGroup) {
 
 function getChunkGroupModules(dep) {
   const modulesSet = new Set();
-
-  // Module dependencies
+  // For ConcatenatedModules in production build
   if (dep.module && dep.module.dependencies) {
     dep.module.dependencies.forEach(dependency => {
       if (dependency.originModule) {
@@ -198,13 +196,11 @@ function getChunkGroupModules(dep) {
       }
     });
   }
-
-  // Chunks
+  // For NormalModules
   dep.block.chunkGroup.chunks.forEach(chunk => {
     for (const module of chunk._modules) {
       modulesSet.add(module.resource);
     }
   });
-
   return modulesSet;
 }

--- a/build/plugins/instrumented-import-dependency-template-plugin.js
+++ b/build/plugins/instrumented-import-dependency-template-plugin.js
@@ -93,7 +93,7 @@ class InstrumentedImportDependencyTemplate extends ImportDependencyTemplate {
     // Add the following properties to the promise returned by import()
     // - `__CHUNK_IDS`: the webpack chunk ids for the dynamic import
     // - `__MODULE_ID`: the webpack module id of the dynamically imported module. Equivalent to require.resolveWeak(path)
-    // - `__I18N_KEYS`: the translation keys used in the client chunk group for this import() 
+    // - `__I18N_KEYS`: the translation keys used in the client chunk group for this import()
     const customContent = chunkIds
       ? `Object.defineProperties(${content}, {
         "__CHUNK_IDS": {value:${JSON.stringify(chunkIds)}},

--- a/test/e2e/assets/test.js
+++ b/test/e2e/assets/test.js
@@ -68,7 +68,7 @@ test('`fusion dev` works with assets', async () => {
     const clientMain = await request(`${url}/_static/client-main.js`);
     t.ok(clientMain, 'serves client-main from memory correctly');
     t.ok(
-      clientMain.includes('"src", "src/main.js")'),
+      clientMain.includes('"src","src/main.js")'),
       'transpiles __dirname and __filename'
     );
     t.ok(

--- a/test/e2e/dynamic-import-translations/fixture/src/main.js
+++ b/test/e2e/dynamic-import-translations/fixture/src/main.js
@@ -1,0 +1,24 @@
+// @noflow
+
+import React from 'react';
+import App from 'fusion-react';
+
+function Root () {
+  const split = import('./split.js');
+  const splitWithChild = import('./split-with-child.js');
+  return (
+    <div>
+      <div data-testid="split">
+        {JSON.stringify(split.__I18N_KEYS)}
+      </div>
+      <div data-testid="split-with-child">
+        {JSON.stringify(splitWithChild.__I18N_KEYS)}
+      </div>
+    </div>
+  );
+}
+
+export default async function start() {
+  const app = new App(<Root />);
+  return app;
+}

--- a/test/e2e/dynamic-import-translations/fixture/src/split-child.js
+++ b/test/e2e/dynamic-import-translations/fixture/src/split-child.js
@@ -1,0 +1,10 @@
+// @noflow
+
+import React from 'react';
+import {Translate} from 'fusion-plugin-i18n-react';
+
+export default function SplitRouteChild() {
+  return (
+    <Translate id="__SPLIT_CHILD__"/>
+  );
+}

--- a/test/e2e/dynamic-import-translations/fixture/src/split-with-child.js
+++ b/test/e2e/dynamic-import-translations/fixture/src/split-with-child.js
@@ -1,0 +1,12 @@
+// @noflow
+
+import React, {Component} from 'react';
+import {withTranslations} from 'fusion-plugin-i18n-react';
+
+import SplitRouteChild from './split-child.js';
+
+function SplitRouteWithChild () {
+  return <SplitRouteChild />;
+}
+
+export default withTranslations(['__SPLIT_WITH_CHILD__'])(SplitRouteWithChild);

--- a/test/e2e/dynamic-import-translations/fixture/src/split.js
+++ b/test/e2e/dynamic-import-translations/fixture/src/split.js
@@ -1,0 +1,10 @@
+// @noflow
+
+import React, {Component} from 'react';
+import {withTranslations} from 'fusion-plugin-i18n-react';
+
+function SplitRoute () {
+  return <div />
+}
+
+export default withTranslations(['__SPLIT__'])(SplitRoute);

--- a/test/e2e/dynamic-import-translations/fixture/translations/en-US.json
+++ b/test/e2e/dynamic-import-translations/fixture/translations/en-US.json
@@ -1,0 +1,5 @@
+{
+  "__SPLIT__": "",
+  "__SPLIT_WITH_CHILD__": "",
+  "__SPLIT_CHILD__": ""
+}

--- a/test/e2e/dynamic-import-translations/test.js
+++ b/test/e2e/dynamic-import-translations/test.js
@@ -3,10 +3,7 @@
 
 const t = require('assert');
 const path = require('path');
-const fs = require('fs');
 const puppeteer = require('puppeteer');
-
-const dev = require('../setup.js');
 
 const {cmd, start} = require('../utils.js');
 
@@ -32,8 +29,8 @@ test('`fusion build` app with split translations integration', async () => {
   t.ok(
     content.includes(
       '<div data-testid="split-with-child">' +
-      '["__SPLIT_CHILD__","__SPLIT_WITH_CHILD__"]' +
-      '</div>'
+        '["__SPLIT_CHILD__","__SPLIT_WITH_CHILD__"]' +
+        '</div>'
     ),
     'translation keys contain keys from child imports'
   );

--- a/test/e2e/dynamic-import-translations/test.js
+++ b/test/e2e/dynamic-import-translations/test.js
@@ -1,0 +1,43 @@
+// @flow
+/* eslint-env node */
+
+const t = require('assert');
+const path = require('path');
+const fs = require('fs');
+const puppeteer = require('puppeteer');
+
+const dev = require('../setup.js');
+
+const {cmd, start} = require('../utils.js');
+
+const dir = path.resolve(__dirname, './fixture');
+
+test('`fusion build` app with split translations integration', async () => {
+  var env = Object.create(process.env);
+  env.NODE_ENV = 'production';
+
+  await cmd(`build --dir=${dir} --production`, {env});
+
+  const {proc, port} = await start(`--dir=${dir}`, {env, cwd: dir});
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const page = await browser.newPage();
+  await page.goto(`http://localhost:${port}/`, {waitUntil: 'load'});
+  const content = await page.content();
+  t.ok(
+    content.includes('<div data-testid="split">["__SPLIT__"]</div>'),
+    'translation keys are added to promise instrumentation'
+  );
+  t.ok(
+    content.includes(
+      '<div data-testid="split-with-child">' +
+      '["__SPLIT_CHILD__","__SPLIT_WITH_CHILD__"]' +
+      '</div>'
+    ),
+    'translation keys contain keys from child imports'
+  );
+
+  browser.close();
+  proc.kill();
+}, 100000);

--- a/test/e2e/empty/test.js
+++ b/test/e2e/empty/test.js
@@ -26,7 +26,7 @@ test('generates error if missing default export', async () => {
     // $FlowFixMe
     t.fail('did not error');
   } catch (e) {
-    t.ok(e.stderr.includes('initialize is not a function'));
+    t.ok(e.stderr.includes(' is not a function'));
   } finally {
     proc.kill();
   }

--- a/test/e2e/noop-test/test.js
+++ b/test/e2e/noop-test/test.js
@@ -31,11 +31,11 @@ test('development env globals', async () => {
   const clientContent = await readFile(clientEntryPath, 'utf8');
 
   t.ok(
-    clientContent.includes(`'main __BROWSER__ is', true`),
+    clientContent.includes(`"main __BROWSER__ is",!0`),
     `__BROWSER__ is transpiled to be true in development`
   );
   t.ok(
-    clientContent.includes(`'main __NODE__ is', false`),
+    clientContent.includes(`"main __NODE__ is",!1`),
     '__NODE__ is transpiled to be false'
   );
 

--- a/test/e2e/transpile-node-modules/test.js
+++ b/test/e2e/transpile-node-modules/test.js
@@ -55,5 +55,5 @@ test('transpiles node_modules', async () => {
     ],
   });
 
-  t.ok(clientVendor.includes(`'fixturepkg_string'`));
+  t.ok(clientVendor.includes(`"fixturepkg_string"`));
 }, 100000);


### PR DESCRIPTION
Annotate dynamic imports with the translation keys the chunk contains

Fixes issues with dynamically loading translations where routing isn't guaranteed to hit the origin the initial request was served from. This will allow looking up a translation by key instead of the id of the chunk that contains it.

Essentially I had to split the i18nManifest state into its `DeferredState` and the `Map` that it resolves to. This way, the server build can wait for the client build to finish (as before) by referencing the `DeferredState` and the instrumentation plugin can use the `Map` directly to lookup translation keys.

This is supplemented by PRs in `fusion-react`, `fusion-plugin-i18n`, and `fusion-plugin-i18n-react`.